### PR TITLE
feat: Enhance RequestDisable2FAHandler for username-based 2FA disabling

### DIFF
--- a/src/include/constants.py
+++ b/src/include/constants.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from include.classes.version import Version
 
-CORE_VERSION = Version("0.2.0.260402_alpha")
+CORE_VERSION = Version("0.2.0.260403_alpha")
 PROTOCOL_VERSION = 11
 
 ROOT_ABSPATH = Path(__file__).resolve().parent.parent

--- a/src/include/handlers/two_factor.py
+++ b/src/include/handlers/two_factor.py
@@ -5,6 +5,8 @@ This module provides handlers for setting up, validating, and canceling
 two-factor authentication using Time-based One-Time Passwords (TOTP).
 """
 
+from operator import xor
+
 import orjson
 
 from include.classes.connection_handler import ConnectionHandler
@@ -146,40 +148,64 @@ class RequestDisable2FAHandler(RequestHandler):
     The user must provide their password for verification.
     """
 
-    # TODO: Allow sysops to disable 2FA for users who lost access
-
     data_schema = {
         "type": "object",
         "properties": {
+            "username": {"type": "string", "minLength": 1},
             "password": {"type": "string", "minLength": 1},
         },
-        "required": ["password"],
+        "oneOf": [
+            {"required": ["username"]},
+            {"required": ["password"]},
+        ],
         "additionalProperties": False,
     }
 
     require_auth = True
 
     def handle(self, handler: ConnectionHandler):
-        password = handler.data["password"]
-        username = handler.username
+        password = handler.data.get("password")
+        username = handler.data.get("username") or handler.username
+        assert xor(password is not None, username != handler.username), (
+            "Must provide either password or target username, but not both"
+        )
 
         success = False
 
         with Session() as session:
-            user = session.get(User, username)
-            if not user or not user.totp_enabled:
-                handler.conclude_request(400, {}, "2FA not enabled or user not found")
-                return
+            if password:
+                user = session.get(User, username)
+                if not user or not user.totp_enabled:
+                    handler.conclude_request(
+                        400, {}, "2FA not enabled or user not found"
+                    )
+                    return
 
-            try:
-                if user.verify_password(password):
-                    if user.status != UserStatus.ACTIVE:
-                        raise UserNotActiveError
-                    user.disable_totp()
-                    success = True
-            except UserNotActiveError:
-                handler.conclude_request(4003, {}, "User account is not active")
-                return 4003, username
+                try:
+                    if user.verify_password(password):
+                        if user.status != UserStatus.ACTIVE:
+                            raise UserNotActiveError
+                        user.disable_totp()
+                        success = True
+                except UserNotActiveError:
+                    handler.conclude_request(4003, {}, "User account is not active")
+                    return 4003, username
+            else:
+                # Targeted 2FA disable by sysop
+                user = session.get(User, username)
+                if not user or not user.totp_enabled:
+                    handler.conclude_request(
+                        400, {}, "2FA not enabled or user not found"
+                    )
+                    return
+
+                requester = User.get_existing(session, handler.username)
+                if Permissions.MANAGE_2FA not in requester.all_permissions:
+                    handler.conclude_request(403, {}, "Permission denied")
+                    return 403, username, handler.username
+
+                user.disable_totp()
+                success = True
 
         if success:
             handler.conclude_request(200, {}, "2FA disabled successfully")

--- a/src/include/handlers/two_factor.py
+++ b/src/include/handlers/two_factor.py
@@ -5,6 +5,8 @@ This module provides handlers for setting up, validating, and canceling
 two-factor authentication using Time-based One-Time Passwords (TOTP).
 """
 
+from operator import xor
+
 import orjson
 
 from include.classes.connection_handler import ConnectionHandler
@@ -165,12 +167,16 @@ class RequestDisable2FAHandler(RequestHandler):
         target_username = handler.data.get("username") or handler.username
         requester_username = handler.username
 
-        if target_username != requester_username and password:
-            handler.conclude_request(
-                400,
-                {},
-                "Password should not be provided when disabling 2FA for another user",
+        is_self = target_username == requester_username
+        has_password = bool(password)
+
+        if xor(is_self, has_password):
+            error_msg = (
+                "Password is required when disabling your own 2FA"
+                if is_self
+                else "Password should not be provided when disabling 2FA for another user"
             )
+            handler.conclude_request(400, {}, error_msg)
             return 400, target_username, requester_username
 
         with Session() as session:

--- a/src/include/handlers/two_factor.py
+++ b/src/include/handlers/two_factor.py
@@ -154,7 +154,7 @@ class RequestDisable2FAHandler(RequestHandler):
             "username": {"type": "string", "minLength": 1},
             "password": {"type": "string", "minLength": 1},
         },
-        "oneOf": [
+        "anyOf": [
             {"required": ["username"]},
             {"required": ["password"]},
         ],
@@ -166,9 +166,14 @@ class RequestDisable2FAHandler(RequestHandler):
     def handle(self, handler: ConnectionHandler):
         password = handler.data.get("password")
         username = handler.data.get("username") or handler.username
-        assert xor(password is not None, username != handler.username), (
-            "Must provide either password or target username, but not both"
-        )
+        if not xor(password is not None, username != handler.username):
+            handler.conclude_request(
+                400,
+                {},
+                "Must provide either password for self-disable or "
+                "username for targeted disable, but not both",
+            )
+            return 400, username
 
         success = False
 

--- a/src/include/handlers/two_factor.py
+++ b/src/include/handlers/two_factor.py
@@ -5,14 +5,11 @@ This module provides handlers for setting up, validating, and canceling
 two-factor authentication using Time-based One-Time Passwords (TOTP).
 """
 
-from operator import xor
-
 import orjson
 
 from include.classes.connection_handler import ConnectionHandler
 from include.classes.enum.permissions import Permissions
 from include.classes.enum.status import UserStatus
-from include.classes.exceptions import UserNotActiveError
 from include.classes.request_handler import RequestHandler
 from include.database.handler import Session
 from include.database.models.classic import User
@@ -165,59 +162,41 @@ class RequestDisable2FAHandler(RequestHandler):
 
     def handle(self, handler: ConnectionHandler):
         password = handler.data.get("password")
-        username = handler.data.get("username") or handler.username
-        if not xor(password is not None, username != handler.username):
+        target_username = handler.data.get("username") or handler.username
+        requester_username = handler.username
+
+        if target_username != requester_username and password:
             handler.conclude_request(
                 400,
                 {},
-                "Must provide either password for self-disable or "
-                "username for targeted disable, but not both",
+                "Password should not be provided when disabling 2FA for another user",
             )
-            return 400, username
-
-        success = False
+            return 400, target_username, requester_username
 
         with Session() as session:
+            user = session.get(User, target_username)
+            if not user or not user.totp_enabled:
+                handler.conclude_request(400, {}, "2FA not enabled or user not found")
+                return 400, target_username, requester_username
+
             if password:
-                user = session.get(User, username)
-                if not user or not user.totp_enabled:
-                    handler.conclude_request(
-                        400, {}, "2FA not enabled or user not found"
-                    )
-                    return
+                if not user.verify_password(password):
+                    handler.conclude_request(401, {}, "Invalid password")
+                    return 401, target_username, requester_username
 
-                try:
-                    if user.verify_password(password):
-                        if user.status != UserStatus.ACTIVE:
-                            raise UserNotActiveError
-                        user.disable_totp()
-                        success = True
-                except UserNotActiveError:
+                if user.status != UserStatus.ACTIVE:
                     handler.conclude_request(4003, {}, "User account is not active")
-                    return 4003, username
+                    return 4003, target_username, requester_username
             else:
-                # Targeted 2FA disable by sysop
-                user = session.get(User, username)
-                if not user or not user.totp_enabled:
-                    handler.conclude_request(
-                        400, {}, "2FA not enabled or user not found"
-                    )
-                    return
-
-                requester = User.get_existing(session, handler.username)
+                requester = User.get_existing(session, requester_username)
                 if Permissions.MANAGE_2FA not in requester.all_permissions:
                     handler.conclude_request(403, {}, "Permission denied")
-                    return 403, username, handler.username
+                    return 403, target_username, requester_username
 
-                user.disable_totp()
-                success = True
+            user.disable_totp()
 
-        if success:
-            handler.conclude_request(200, {}, "2FA disabled successfully")
-        else:
-            handler.conclude_request(401, {}, "Invalid password")
-
-        return (0 if success else 401), username
+        handler.conclude_request(200, {}, "2FA disabled successfully")
+        return 0, target_username, requester_username
 
 
 class RequestCancel2FASetupHandler(RequestHandler):


### PR DESCRIPTION
## Summary by Sourcery

Allow disabling 2FA either by authenticating as the user or by specifying a target username with appropriate permissions, and bump the core version.

New Features:
- Support disabling 2FA for other users by specifying their username when the requester has manage-2FA permissions.

Enhancements:
- Relax the request schema to accept either a password for self-disabling or a username for privileged disabling while enforcing consistent response codes and payloads.

Chores:
- Update the core version constant to 0.2.0.260403_alpha.