### PR TITLE
feat: Implement centralized file reference counting in database

### DIFF
--- a/src/include/database/models/entity.py
+++ b/src/include/database/models/entity.py
@@ -11,7 +11,7 @@ from include.classes.access_rule import AccessRuleBase
 from include.classes.enum.status import DocumentRevisionStatus, EntityStatus
 from include.classes.exceptions import NoActiveRevisionsError
 from include.conf_loader import global_config
-from include.constants import AVAILABLE_ACCESS_TYPES, QUERY_CHUNK_SIZE
+from include.constants import AVAILABLE_ACCESS_TYPES, MAX_PARAM_SIZE, QUERY_CHUNK_SIZE
 from include.database.handler import Base
 from include.database.models.classic import User
 from include.database.models.file import (
@@ -38,33 +38,41 @@ def _batch_count_other_revisions(
     # Return total references to each file EXCLUDING references that come
     # from the provided exclude_doc_ids set. This centralizes counting via
     # `count_file_references` so new FK references are automatically handled.
-    counts: dict[str, int] = {}
-    if not file_ids:
-        return counts
+
+    # Materialize iterables so they can be safely iterated multiple times.
+    file_ids_list = list(file_ids)
+    if not file_ids_list:
+        return {}
 
     if isinstance(exclude_doc_ids, str):
-        exclude_doc_ids = [exclude_doc_ids]
+        exclude_doc_ids_list = [exclude_doc_ids]
     else:
-        exclude_doc_ids = list(exclude_doc_ids)
+        exclude_doc_ids_list = list(exclude_doc_ids)
 
     # Get total references across all tables (uses reflected FKs).
-    total_refs = count_file_references(session, list(file_ids))
+    total_refs = count_file_references(session, file_ids_list)
 
     # Count references coming from the excluded documents (DocumentRevision only).
+    # The query combines `file_id IN (...)` and `document_id IN (...)`, so both
+    # dimensions must be chunked to keep total bind variables under MAX_PARAM_SIZE.
+    exclude_chunk_size = max(1, MAX_PARAM_SIZE - QUERY_CHUNK_SIZE)
     excluded_counts: dict[str, int] = {}
-    for f_chunk in batched(file_ids, QUERY_CHUNK_SIZE):
-        q = (
-            session.query(DocumentRevision.file_id, func.count(DocumentRevision.id))
-            .filter(DocumentRevision.file_id.in_(list(f_chunk)))
-            .filter(DocumentRevision.document_id.in_(list(exclude_doc_ids)))
-            .group_by(DocumentRevision.file_id)
-        )
-        rows = q.all()
-        excluded_counts.update({file_id: count for file_id, count in rows})
+    for f_chunk in batched(file_ids_list, QUERY_CHUNK_SIZE):
+        for e_chunk in batched(exclude_doc_ids_list, exclude_chunk_size):
+            rows = (
+                session.query(DocumentRevision.file_id, func.count(DocumentRevision.id))
+                .filter(DocumentRevision.file_id.in_(list(f_chunk)))
+                .filter(DocumentRevision.document_id.in_(list(e_chunk)))
+                .group_by(DocumentRevision.file_id)
+                .all()
+            )
+            for file_id, count in rows:
+                excluded_counts[file_id] = excluded_counts.get(file_id, 0) + count
 
-    for fid in file_ids:
+    counts: dict[str, int] = {}
+    for fid in file_ids_list:
         total = total_refs.get(fid, 0)
-        excluded = int(excluded_counts.get(fid, 0))
+        excluded = excluded_counts.get(fid, 0)
         counts[fid] = max(0, total - excluded)
 
     return counts
@@ -582,10 +590,7 @@ class DocumentRevision(Base):
         other_refs = max(0, total - 1)
 
         if other_refs == 0:
-            try:
-                self.file.delete()
-            except PermissionError:
-                raise
+            self.file.delete()
             session.delete(self.file)
 
     def __repr__(self) -> str:

--- a/src/include/database/models/entity.py
+++ b/src/include/database/models/entity.py
@@ -11,7 +11,7 @@ from include.classes.access_rule import AccessRuleBase
 from include.classes.enum.status import DocumentRevisionStatus, EntityStatus
 from include.classes.exceptions import NoActiveRevisionsError
 from include.conf_loader import global_config
-from include.constants import AVAILABLE_ACCESS_TYPES, MAX_PARAM_SIZE, QUERY_CHUNK_SIZE
+from include.constants import AVAILABLE_ACCESS_TYPES, QUERY_CHUNK_SIZE
 from include.database.handler import Base
 from include.database.models.classic import User
 from include.database.models.file import (
@@ -19,6 +19,7 @@ from include.database.models.file import (
     FileTask,
     _queue_deferred_file_deletion,
 )
+from include.util.count import count_file_references
 from include.util.fetch.fetch import batch_prefetch_granted_ids, prefetch_user_blocks
 
 
@@ -34,6 +35,9 @@ def _batch_count_other_revisions(
         file_ids: 待检查的文件 ID 列表。
         exclude_doc_ids: 单个文档 ID 或文档 ID 集合。这些文档对文件的引用将不被计入。
     """
+    # Return total references to each file EXCLUDING references that come
+    # from the provided exclude_doc_ids set. This centralizes counting via
+    # `count_file_references` so new FK references are automatically handled.
     counts: dict[str, int] = {}
     if not file_ids:
         return counts
@@ -43,22 +47,25 @@ def _batch_count_other_revisions(
     else:
         exclude_doc_ids = list(exclude_doc_ids)
 
-    EXCLUDE_CHUNK_SIZE = MAX_PARAM_SIZE - QUERY_CHUNK_SIZE
+    # Get total references across all tables (uses reflected FKs).
+    total_refs = count_file_references(session, list(file_ids))
 
+    # Count references coming from the excluded documents (DocumentRevision only).
+    excluded_counts: dict[str, int] = {}
     for f_chunk in batched(file_ids, QUERY_CHUNK_SIZE):
-        query = session.query(
-            DocumentRevision.file_id, func.count(DocumentRevision.id)
-        ).filter(DocumentRevision.file_id.in_(list(f_chunk)))
-
-        for e_chunk in batched(exclude_doc_ids, EXCLUDE_CHUNK_SIZE):
-            query = query.filter(DocumentRevision.document_id.not_in(list(e_chunk)))
-
-        rows = query.group_by(DocumentRevision.file_id).all()
-        counts.update({file_id: count for file_id, count in rows})
+        q = (
+            session.query(DocumentRevision.file_id, func.count(DocumentRevision.id))
+            .filter(DocumentRevision.file_id.in_(list(f_chunk)))
+            .filter(DocumentRevision.document_id.in_(list(exclude_doc_ids)))
+            .group_by(DocumentRevision.file_id)
+        )
+        rows = q.all()
+        excluded_counts.update({file_id: count for file_id, count in rows})
 
     for fid in file_ids:
-        if fid not in counts:
-            counts[fid] = 0
+        total = int(total_refs.get(fid, 0))
+        excluded = int(excluded_counts.get(fid, 0))
+        counts[fid] = max(0, total - excluded)
 
     return counts
 
@@ -470,14 +477,11 @@ class Document(BaseObject):
         all_file_ids = {row[1] for row in revision_tuples if row[1]}
 
         # Task 3: Chunked batch reference count queries to avoid variable limit.
-        other_rev_counts = _batch_count_other_revisions(session, all_file_ids, self.id)
-        avatar_counts = _batch_count_avatar_usages(session, all_file_ids)
+        other_counts = _batch_count_other_revisions(session, all_file_ids, self.id)
 
         # Determine which files are exclusively referenced by this document's revisions.
         deletable_file_ids = {
-            fid
-            for fid in all_file_ids
-            if other_rev_counts.get(fid, 0) + avatar_counts.get(fid, 0) == 0
+            fid for fid in all_file_ids if other_counts.get(fid, 0) == 0
         }
 
         # Load File ORM objects needed for deletion (chunked to stay within SQLite limits).
@@ -589,16 +593,10 @@ class DocumentRevision(Base):
         session = object_session(self)
         if not session:
             raise Exception("The object is not associated with a session")
-
-        other_refs = (
-            session.query(DocumentRevision)
-            .filter(DocumentRevision.file_id == self.file_id)
-            .filter(DocumentRevision.id != self.id)
-            .count()
-            +
-            # Check if file is not used as any avatar property
-            session.query(User).filter(User.avatar_id == self.file_id).count()
-        )
+        # Use centralized reference counting across all FK references.
+        total = count_file_references(session, [self.file_id]).get(self.file_id, 0)
+        # subtract this revision's own reference
+        other_refs = max(0, int(total) - 1)
 
         if other_refs == 0:
             try:

--- a/src/include/database/models/entity.py
+++ b/src/include/database/models/entity.py
@@ -63,29 +63,10 @@ def _batch_count_other_revisions(
         excluded_counts.update({file_id: count for file_id, count in rows})
 
     for fid in file_ids:
-        total = int(total_refs.get(fid, 0))
+        total = total_refs.get(fid, 0)
         excluded = int(excluded_counts.get(fid, 0))
         counts[fid] = max(0, total - excluded)
 
-    return counts
-
-
-def _batch_count_avatar_usages(session: Session, file_ids) -> dict:
-    """Count User records using any of the given ``file_ids`` as their avatar.
-
-    Queries are chunked to stay within SQLite's bind-variable limit.
-    """
-    counts: dict = {}
-    if not file_ids:
-        return counts
-    for chunk in batched(file_ids, QUERY_CHUNK_SIZE):
-        rows = (
-            session.query(User.avatar_id, func.count())
-            .filter(User.avatar_id.in_(list(chunk)))
-            .group_by(User.avatar_id)
-            .all()
-        )
-        counts.update({file_id: count for file_id, count in rows})
     return counts
 
 
@@ -593,10 +574,12 @@ class DocumentRevision(Base):
         session = object_session(self)
         if not session:
             raise Exception("The object is not associated with a session")
+        if not self.file_id:
+            return
         # Use centralized reference counting across all FK references.
         total = count_file_references(session, [self.file_id]).get(self.file_id, 0)
-        # subtract this revision's own reference
-        other_refs = max(0, int(total) - 1)
+        # Subtract this revision's own reference.
+        other_refs = max(0, total - 1)
 
         if other_refs == 0:
             try:

--- a/src/include/util/bulk/purge.py
+++ b/src/include/util/bulk/purge.py
@@ -20,12 +20,14 @@ def purge_documents_bulk(session: Session, document_ids: List[str]):
     if not document_ids:
         return
 
-    # 1. 批量获取所有受影响的修订版本 ID 和文件 ID
-    revision_data = (
-        session.query(DocumentRevision.id, DocumentRevision.file_id)
-        .filter(DocumentRevision.document_id.in_(document_ids))
-        .all()
-    )
+    # 1. 批量获取所有受影响的修订版本 ID 和文件 ID（分块查询以避免超出绑定变量限制）
+    revision_data = []
+    for chunk in batched(document_ids, QUERY_CHUNK_SIZE):
+        revision_data.extend(
+            session.query(DocumentRevision.id, DocumentRevision.file_id)
+            .filter(DocumentRevision.document_id.in_(list(chunk)))
+            .all()
+        )
 
     if not revision_data:
         # 如果这些文档都没有修订版本，直接删除文档记录即可

--- a/src/include/util/bulk/purge.py
+++ b/src/include/util/bulk/purge.py
@@ -7,7 +7,6 @@ from include.constants import QUERY_CHUNK_SIZE
 from include.database.models.entity import (
     Document,
     DocumentRevision,
-    _batch_count_avatar_usages,
     _batch_count_other_revisions,
 )
 from include.database.models.file import File, FileTask, _queue_deferred_file_deletion
@@ -40,19 +39,11 @@ def purge_documents_bulk(session: Session, document_ids: List[str]):
     file_ids = {r[1] for r in revision_data if r[1]}
 
     # 2. 批量引用计数检查
-    # 我们需要确认这些文件是否被“这批文档以外”的其他东西引用
-    # 修改原本的计数逻辑，使其支持 excluded_doc_ids 集合
-    other_rev_counts = _batch_count_other_revisions(
-        session, list(file_ids), document_ids
-    )
-    avatar_counts = _batch_count_avatar_usages(session, list(file_ids))
+    # 使用集中计数，排除来自这批文档的引用后若为 0 则可删除
+    other_counts = _batch_count_other_revisions(session, list(file_ids), document_ids)
 
     # 找出仅被这批文档引用、可以物理删除的文件 ID
-    deletable_file_ids = [
-        fid
-        for fid in file_ids
-        if other_rev_counts.get(fid, 0) + avatar_counts.get(fid, 0) == 0
-    ]
+    deletable_file_ids = [fid for fid in file_ids if other_counts.get(fid, 0) == 0]
 
     # 3. 批量删除 (使用 SQL 级别的 delete)
     # 我们处于 no_autoflush 模式下运行此块

--- a/src/include/util/count.py
+++ b/src/include/util/count.py
@@ -1,7 +1,7 @@
 __all__ = ["count_file_references"]
 
 from itertools import islice
-from typing import Any, Iterable, cast
+from typing import Any, Sequence, cast
 
 from sqlalchemy import MetaData, Table, func, select, union_all
 from sqlalchemy.engine import Engine
@@ -9,40 +9,74 @@ from sqlalchemy.orm import Session
 
 from include.constants import QUERY_CHUNK_SIZE
 
-_CACHED_REFS = None
+# Cache keyed by engine URL so that different engines (e.g. in tests) each
+# get their own reflected FK list.  Call ``_clear_file_references_cache()``
+# to force a re-reflection.
+_CACHED_REFS: dict[str, list[tuple[Table, str]]] = {}
+
+
+def _clear_file_references_cache() -> None:
+    """Reset the cached FK reflection data.
+
+    Useful in test fixtures or after schema migrations.
+    """
+    _CACHED_REFS.clear()
 
 
 def _get_file_references(engine: Engine) -> list[tuple[Table, str]]:
-    global _CACHED_REFS
-    if _CACHED_REFS is not None:
-        return _CACHED_REFS
+    """Return ``(table, column_name)`` pairs for every FK that points to the
+    ``files`` table, **excluding** cascade-dependent relationships.
+
+    Foreign keys declared with ``ondelete="CASCADE"`` represent operational
+    metadata (e.g. ``file_tasks``) that is automatically removed when the
+    parent file row is deleted — they are not independent "usage" references
+    and must not block file deletion.
+    """
+    cache_key = str(engine.url)
+    if cache_key in _CACHED_REFS:
+        return _CACHED_REFS[cache_key]
 
     meta = MetaData()
     meta.reflect(bind=engine)
 
-    refs = []
+    refs: list[tuple[Table, str]] = []
     files_table_name = "files"
     for table in meta.sorted_tables:
         for col in table.columns:
             for fk in col.foreign_keys:
-                if fk.column.table.name == files_table_name:
-                    refs.append((table, col.name))
+                if fk.column.table.name != files_table_name:
+                    continue
+                # Skip FK relationships with CASCADE delete — those rows are
+                # dependent metadata, not independent references.
+                ondelete = (fk.ondelete or "").upper()
+                if ondelete == "CASCADE":
+                    continue
+                refs.append((table, col.name))
 
-    _CACHED_REFS = refs
+    _CACHED_REFS[cache_key] = refs
     return refs
 
 
-def count_file_references(session: Session, file_ids: Iterable[Any] | None = None):
-    """
-    Count references to files in the database.
+def count_file_references(
+    session: Session,
+    file_ids: Sequence[Any] | None = None,
+) -> dict[Any, int]:
+    """Count independent usage references to files across the database.
+
+    Uses SQLAlchemy metadata reflection to discover every foreign key that
+    points to the ``files`` table (excluding cascade-dependent tables like
+    ``file_tasks``), then aggregates the reference counts.
 
     Args:
-        session (Session): The SQLAlchemy session to use for the query.
-        file_ids (Iterable[Any] | None): An optional iterable of file IDs to filter
-        by. If None, counts references for all files.
-    """
+        session: The SQLAlchemy session to use for the query.
+        file_ids: An optional sequence of file IDs to filter by.  If *None*,
+            counts references for **all** files.
 
-    if file_ids is not None and not file_ids:
+    Returns:
+        A mapping of ``{file_id: total_reference_count}``.  File IDs with
+        zero references are omitted.
+    """
+    if file_ids is not None and len(file_ids) == 0:
         return {}
 
     engine = cast(Engine, session.get_bind())
@@ -51,7 +85,7 @@ def count_file_references(session: Session, file_ids: Iterable[Any] | None = Non
     if not refs:
         return {}
 
-    def _execute_query(chunk_ids):
+    def _execute_query(chunk_ids: Sequence[Any] | None) -> dict[Any, int]:
         subqueries = []
         for table, colname in refs:
             col = table.c[colname]
@@ -60,7 +94,7 @@ def count_file_references(session: Session, file_ids: Iterable[Any] | None = Non
             )
 
             if chunk_ids is not None:
-                stmt = stmt.where(col.in_(chunk_ids))
+                stmt = stmt.where(col.in_(list(chunk_ids)))
 
             stmt = stmt.group_by(col)
             subqueries.append(stmt)
@@ -71,12 +105,12 @@ def count_file_references(session: Session, file_ids: Iterable[Any] | None = Non
         )
 
         rows = session.execute(final).all()
-        return {row.file_id: row.total for row in rows}
+        return {row.file_id: int(row.total) for row in rows}
 
     if file_ids is None:
         return _execute_query(None)
 
-    result = {}
+    result: dict[Any, int] = {}
     iterator = iter(file_ids)
     while chunk := tuple(islice(iterator, QUERY_CHUNK_SIZE)):
         chunk_result = _execute_query(chunk)

--- a/src/include/util/count.py
+++ b/src/include/util/count.py
@@ -1,0 +1,86 @@
+__all__ = ["count_file_references"]
+
+from itertools import islice
+from typing import Any, Iterable, cast
+
+from sqlalchemy import MetaData, Table, func, select, union_all
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+
+from include.constants import QUERY_CHUNK_SIZE
+
+_CACHED_REFS = None
+
+
+def _get_file_references(engine: Engine) -> list[tuple[Table, str]]:
+    global _CACHED_REFS
+    if _CACHED_REFS is not None:
+        return _CACHED_REFS
+
+    meta = MetaData()
+    meta.reflect(bind=engine)
+
+    refs = []
+    files_table_name = "files"
+    for table in meta.sorted_tables:
+        for col in table.columns:
+            for fk in col.foreign_keys:
+                if fk.column.table.name == files_table_name:
+                    refs.append((table, col.name))
+
+    _CACHED_REFS = refs
+    return refs
+
+
+def count_file_references(session: Session, file_ids: Iterable[Any] | None = None):
+    """
+    Count references to files in the database.
+
+    Args:
+        session (Session): The SQLAlchemy session to use for the query.
+        file_ids (Iterable[Any] | None): An optional iterable of file IDs to filter
+        by. If None, counts references for all files.
+    """
+
+    if file_ids is not None and not file_ids:
+        return {}
+
+    engine = cast(Engine, session.get_bind())
+    refs = _get_file_references(engine)
+
+    if not refs:
+        return {}
+
+    def _execute_query(chunk_ids):
+        subqueries = []
+        for table, colname in refs:
+            col = table.c[colname]
+            stmt = select(col.label("file_id"), func.count().label("cnt")).where(
+                col.isnot(None)
+            )
+
+            if chunk_ids is not None:
+                stmt = stmt.where(col.in_(chunk_ids))
+
+            stmt = stmt.group_by(col)
+            subqueries.append(stmt)
+
+        union = union_all(*subqueries).alias("u")
+        final = select(union.c.file_id, func.sum(union.c.cnt).label("total")).group_by(
+            union.c.file_id
+        )
+
+        rows = session.execute(final).all()
+        return {row.file_id: row.total for row in rows}
+
+    if file_ids is None:
+        return _execute_query(None)
+
+    result = {}
+    iterator = iter(file_ids)
+    while chunk := tuple(islice(iterator, QUERY_CHUNK_SIZE)):
+        chunk_result = _execute_query(chunk)
+        for k, v in chunk_result.items():
+            result[k] = result.get(k, 0) + v
+
+    return result

--- a/src/include/util/count.py
+++ b/src/include/util/count.py
@@ -1,4 +1,4 @@
-__all__ = ["count_file_references"]
+__all__ = ["count_file_references", "_clear_file_references_cache"]
 
 from itertools import islice
 from typing import Any, Sequence, cast

--- a/tests/test_file_ref_count.py
+++ b/tests/test_file_ref_count.py
@@ -23,7 +23,7 @@ being counted were committed in earlier transactions.
 import sys
 from itertools import batched
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import pytest
 from sqlalchemy import (
@@ -165,7 +165,7 @@ def _rev(doc_id: str, file_id: str) -> MDocumentRevision:
     return MDocumentRevision(document_id=doc_id, file_id=file_id)
 
 
-def _user(name: str, avatar_id: str = None) -> MUser:
+def _user(name: str, avatar_id: Optional[str] = None) -> MUser:
     return MUser(username=name, avatar_id=avatar_id)
 
 
@@ -325,7 +325,7 @@ class TestCountFileReferences:
         """
         n = QUERY_CHUNK_SIZE + 50  # spans 2 chunks
 
-        objs = [_doc("d_bulk")]
+        objs: list[Any] = [_doc("d_bulk")]
         file_ids = []
         for i in range(n):
             fid = f"file_{i:04d}"
@@ -504,7 +504,7 @@ class TestBatchCountOtherRevisionsPattern:
         with a mix of deletable and non-deletable files."""
         n = QUERY_CHUNK_SIZE + 20
 
-        objs = [_doc("d_excluded"), _doc("d_other")]
+        objs: list[Any] = [_doc("d_excluded"), _doc("d_other")]
 
         # First half: referenced only by excluded doc → should be deletable
         deletable_ids = [f"del_{i:04d}" for i in range(n // 2)]
@@ -534,7 +534,7 @@ class TestBatchCountOtherRevisionsPattern:
         exclude_chunk = MAX_PARAM_SIZE - QUERY_CHUNK_SIZE
         n_docs = exclude_chunk + 10  # force at least 2 chunks
 
-        objs = [_file("f1")]
+        objs: list[Any] = [_file("f1")]
         doc_ids = []
         for i in range(n_docs):
             did = f"d_excl_{i:04d}"

--- a/tests/test_file_ref_count.py
+++ b/tests/test_file_ref_count.py
@@ -198,6 +198,29 @@ class TestCountFileReferences:
         result = count_file_references(session, ["f_orphan"])
         assert "f_orphan" not in result
 
+    def test_nonexistent_file_ids_returns_empty(self, session):
+        """IDs that don't exist in any table should yield an empty result."""
+        _seed(session, _file("f_real"), _doc("d1"), _rev("d1", "f_real"))
+
+        result = count_file_references(session, ["missing1", "missing2"])
+        assert result == {}
+
+    def test_mix_of_existing_and_nonexistent_ids(self, session):
+        """Only existing *referenced* IDs should appear in the result;
+        non-existent IDs must be silently omitted."""
+        _seed(
+            session,
+            _file("f_exists"),
+            _doc("d1"),
+            _rev("d1", "f_exists"),
+            _file("f_no_refs"),
+        )
+
+        result = count_file_references(
+            session, ["f_exists", "f_no_refs", "totally_missing"]
+        )
+        assert result == {"f_exists": 1}
+
     def test_single_revision_reference(self, session):
         """A file referenced by one DocumentRevision should have count=1."""
         _seed(session, _file("f1"), _doc("d1"), _rev("d1", "f1"))

--- a/tests/test_file_ref_count.py
+++ b/tests/test_file_ref_count.py
@@ -1,0 +1,524 @@
+"""
+Unit tests for centralized file reference counting.
+
+Tests cover:
+  - count_file_references(): reflected-FK based counting across multiple tables
+  - CASCADE FK exclusion (file_tasks should not be counted)
+  - QUERY_CHUNK_SIZE chunking correctness
+  - The "total minus excluded" pattern used by _batch_count_other_revisions
+  - Cache isolation across different engines
+
+These tests are fully self-contained: they use an in-memory SQLite database
+with mirror models that replicate the production FK structure, so they do NOT
+require a running server or config.toml.
+
+NOTE: seed data is *committed* (not merely flushed) before counting because
+``count_file_references`` uses reflected Table objects from a separate
+``MetaData`` instance.  Reflected-table queries may open a different
+connection than the Session's ORM connection, so uncommitted data is
+invisible to them.  In production this is not a problem because references
+being counted were committed in earlier transactions.
+"""
+
+import sys
+from itertools import batched
+from pathlib import Path
+from typing import List, Optional
+
+import pytest
+from sqlalchemy import (
+    VARCHAR,
+    Float,
+    ForeignKey,
+    Integer,
+    Text,
+    create_engine,
+    func,
+)
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    Session,
+    mapped_column,
+    sessionmaker,
+)
+
+# ---------------------------------------------------------------------------
+# Make ``include`` importable without the full project config.
+# count.py → include.constants → include.classes.version (no config needed).
+# ---------------------------------------------------------------------------
+_src = str(Path(__file__).resolve().parent.parent / "src")
+if _src not in sys.path:
+    sys.path.insert(0, _src)
+
+from include.constants import MAX_PARAM_SIZE, QUERY_CHUNK_SIZE  # noqa: E402
+from include.util.count import (  # noqa: E402
+    _clear_file_references_cache,
+    _get_file_references,
+    count_file_references,
+)
+
+# ========================== Mirror ORM models ==============================
+# These replicate ONLY the FK structure relevant to file reference counting.
+# Table/column names MUST match production so reflected metadata lines up.
+# ==========================================================================
+
+
+class _Base(DeclarativeBase):
+    pass
+
+
+class MFile(_Base):
+    """Mirror of ``files`` table."""
+
+    __tablename__ = "files"
+    id: Mapped[str] = mapped_column(VARCHAR(255), primary_key=True)
+    path: Mapped[str] = mapped_column(Text, nullable=False, default="/dev/null")
+    created_time: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+
+
+class MDocument(_Base):
+    """Mirror of ``documents`` table (minimal)."""
+
+    __tablename__ = "documents"
+    id: Mapped[str] = mapped_column(VARCHAR(255), primary_key=True)
+
+
+class MDocumentRevision(_Base):
+    """Mirror of ``document_revisions`` table — FK to files WITHOUT cascade."""
+
+    __tablename__ = "document_revisions"
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    document_id: Mapped[str] = mapped_column(
+        VARCHAR(255), ForeignKey("documents.id"), nullable=False
+    )
+    file_id: Mapped[str] = mapped_column(ForeignKey("files.id"))
+
+
+class MUser(_Base):
+    """Mirror of ``users`` table — avatar_id FK to files WITHOUT cascade."""
+
+    __tablename__ = "users"
+    username: Mapped[str] = mapped_column(VARCHAR(64), primary_key=True)
+    avatar_id: Mapped[Optional[str]] = mapped_column(
+        ForeignKey("files.id"), nullable=True
+    )
+
+
+class MFileTask(_Base):
+    """Mirror of ``file_tasks`` table — FK to files WITH CASCADE.
+
+    This table should be EXCLUDED from reference counting because its rows
+    are auto-removed when the parent file is deleted.
+    """
+
+    __tablename__ = "file_tasks"
+    id: Mapped[str] = mapped_column(VARCHAR(255), primary_key=True)
+    file_id: Mapped[str] = mapped_column(
+        VARCHAR(255), ForeignKey("files.id", ondelete="CASCADE"), nullable=False
+    )
+
+
+# =========================== Pytest fixtures ===============================
+
+
+@pytest.fixture()
+def engine():
+    """Create a fresh in-memory SQLite engine for each test."""
+    _clear_file_references_cache()
+    eng = create_engine("sqlite:///:memory:")
+    _Base.metadata.create_all(eng)
+    yield eng
+    eng.dispose()
+    _clear_file_references_cache()
+
+
+@pytest.fixture()
+def session(engine):
+    """Provide a session bound to the in-memory engine."""
+    factory = sessionmaker(bind=engine)
+    sess = factory()
+    yield sess
+    sess.close()
+
+
+# ======================== Helper: seed data ================================
+
+
+def _seed(session: Session, *objects) -> None:
+    """Add objects to the session, commit, then clear the reflection cache
+    so ``count_file_references`` re-reflects the (now visible) schema."""
+    session.add_all(objects)
+    session.commit()
+    _clear_file_references_cache()
+
+
+def _file(fid: str) -> MFile:
+    return MFile(id=fid, path=f"/tmp/{fid}", created_time=0.0)
+
+
+def _doc(did: str) -> MDocument:
+    return MDocument(id=did)
+
+
+def _rev(doc_id: str, file_id: str) -> MDocumentRevision:
+    return MDocumentRevision(document_id=doc_id, file_id=file_id)
+
+
+def _user(name: str, avatar_id: str = None) -> MUser:
+    return MUser(username=name, avatar_id=avatar_id)
+
+
+def _task(tid: str, file_id: str) -> MFileTask:
+    return MFileTask(id=tid, file_id=file_id)
+
+
+# ============================== Tests =====================================
+# ------------ count_file_references: basic counting -----------------------
+
+
+class TestCountFileReferences:
+    """Core tests for the count_file_references utility."""
+
+    def test_empty_file_ids_returns_empty(self, session):
+        """Passing an empty list should return {} immediately."""
+        assert count_file_references(session, []) == {}
+
+    def test_none_file_ids_counts_all(self, session):
+        """Passing None should count references for every file in the DB."""
+        _seed(session, _file("f1"), _doc("d1"), _rev("d1", "f1"))
+
+        result = count_file_references(session, None)
+        assert result["f1"] == 1
+
+    def test_unreferenced_file_omitted(self, session):
+        """A file with zero references should not appear in the result."""
+        _seed(session, _file("f_orphan"))
+
+        result = count_file_references(session, ["f_orphan"])
+        assert "f_orphan" not in result
+
+    def test_single_revision_reference(self, session):
+        """A file referenced by one DocumentRevision should have count=1."""
+        _seed(session, _file("f1"), _doc("d1"), _rev("d1", "f1"))
+
+        result = count_file_references(session, ["f1"])
+        assert result["f1"] == 1
+
+    def test_multiple_revision_references(self, session):
+        """A file referenced by three revisions should have count=3."""
+        _seed(
+            session,
+            _file("f1"),
+            _doc("d1"),
+            _doc("d2"),
+            _doc("d3"),
+            _rev("d1", "f1"),
+            _rev("d2", "f1"),
+            _rev("d3", "f1"),
+        )
+
+        result = count_file_references(session, ["f1"])
+        assert result["f1"] == 3
+
+    # ---------- Counting across multiple FK tables -------------------------
+
+    def test_avatar_reference_counted(self, session):
+        """User.avatar_id should be counted as an independent reference."""
+        _seed(session, _file("f1"), _user("alice", avatar_id="f1"))
+
+        result = count_file_references(session, ["f1"])
+        assert result["f1"] == 1
+
+    def test_cross_table_aggregation(self, session):
+        """References from both document_revisions and users should sum up."""
+        _seed(
+            session,
+            _file("f1"),
+            _doc("d1"),
+            _rev("d1", "f1"),
+            _user("bob", avatar_id="f1"),
+        )
+
+        result = count_file_references(session, ["f1"])
+        assert result["f1"] == 2  # 1 revision + 1 avatar
+
+    # ---------- CASCADE FK exclusion (file_tasks) --------------------------
+
+    def test_cascade_fk_excluded(self, session):
+        """file_tasks (CASCADE FK) must NOT inflate the reference count."""
+        _seed(session, _file("f1"), _task("t1", "f1"), _task("t2", "f1"))
+
+        result = count_file_references(session, ["f1"])
+        # file_tasks should be excluded → file has zero independent references
+        assert result.get("f1", 0) == 0
+
+    def test_cascade_fk_does_not_block_deletion(self, session):
+        """A file with only CASCADE refs + 1 revision should have count=1,
+        proving the tasks don't inflate the total."""
+        _seed(
+            session,
+            _file("f1"),
+            _doc("d1"),
+            _rev("d1", "f1"),
+            _task("t1", "f1"),
+            _task("t2", "f1"),
+            _task("t3", "f1"),
+        )
+
+        result = count_file_references(session, ["f1"])
+        assert result["f1"] == 1  # Only the revision counts
+
+    # ---------- Multiple file IDs in a single call -------------------------
+
+    def test_multiple_files(self, session):
+        """Counting multiple files in one call should return correct
+        per-file totals."""
+        _seed(
+            session,
+            _file("fa"),
+            _file("fb"),
+            _file("fc"),
+            _doc("d1"),
+            _doc("d2"),
+            _rev("d1", "fa"),
+            _rev("d1", "fb"),
+            _rev("d2", "fb"),
+            _user("alice", avatar_id="fc"),
+        )
+
+        result = count_file_references(session, ["fa", "fb", "fc"])
+        assert result["fa"] == 1
+        assert result["fb"] == 2
+        assert result["fc"] == 1
+
+    # ---------- QUERY_CHUNK_SIZE chunking ----------------------------------
+
+    def test_chunking_correctness(self, session):
+        """Verify correct totals when file_ids exceeds QUERY_CHUNK_SIZE.
+
+        We create more files than QUERY_CHUNK_SIZE, each referenced once,
+        and confirm every single one gets count=1.
+        """
+        n = QUERY_CHUNK_SIZE + 50  # spans 2 chunks
+
+        objs = [_doc("d_bulk")]
+        file_ids = []
+        for i in range(n):
+            fid = f"file_{i:04d}"
+            file_ids.append(fid)
+            objs.append(_file(fid))
+            objs.append(_rev("d_bulk", fid))
+        _seed(session, *objs)
+
+        result = count_file_references(session, file_ids)
+        assert len(result) == n
+        for fid in file_ids:
+            assert result[fid] == 1, (
+                f"Expected count=1 for {fid}, got {result.get(fid)}"
+            )
+
+    # ---------- Cache isolation --------------------------------------------
+
+    def test_cache_isolation_across_engines(self, tmp_path):
+        """Different engines (different URLs) should each get their own
+        reflected FK list."""
+        _clear_file_references_cache()
+
+        db1 = tmp_path / "db1.sqlite"
+        db2 = tmp_path / "db2.sqlite"
+        eng1 = create_engine(f"sqlite:///{db1}")
+        eng2 = create_engine(f"sqlite:///{db2}")
+        _Base.metadata.create_all(eng1)
+        _Base.metadata.create_all(eng2)
+
+        refs1 = _get_file_references(eng1)
+        refs2 = _get_file_references(eng2)
+
+        # Both should have results and be independent objects.
+        assert len(refs1) > 0
+        assert len(refs2) > 0
+        assert refs1 is not refs2
+
+        eng1.dispose()
+        eng2.dispose()
+        _clear_file_references_cache()
+
+    def test_cache_cleared(self):
+        """_clear_file_references_cache should empty the cache."""
+        _clear_file_references_cache()
+
+        eng = create_engine("sqlite:///:memory:")
+        _Base.metadata.create_all(eng)
+        _get_file_references(eng)
+
+        _clear_file_references_cache()
+        from include.util.count import _CACHED_REFS
+
+        assert len(_CACHED_REFS) == 0
+
+        eng.dispose()
+
+    # ---------- Return type guarantees ------------------------------------
+
+    def test_return_values_are_int(self, session):
+        """All returned counts must be plain int, not SQLAlchemy numerics."""
+        _seed(session, _file("f1"), _doc("d1"), _rev("d1", "f1"))
+
+        result = count_file_references(session, ["f1"])
+        for v in result.values():
+            assert type(v) is int
+
+
+# ========= _batch_count_other_revisions algorithm pattern =================
+# The actual function lives in entity.py and has deep import dependencies
+# (config, handler, etc.) so we test the ALGORITHM here: total_refs minus
+# excluded_refs should yield the "other" reference count.
+# =========================================================================
+
+
+class TestBatchCountOtherRevisionsPattern:
+    """Tests for the 'total minus excluded' pattern used by
+    _batch_count_other_revisions."""
+
+    @staticmethod
+    def _count_other_refs(
+        session: Session,
+        file_ids: List[str],
+        exclude_doc_ids: List[str],
+    ) -> dict:
+        """Local reimplementation of _batch_count_other_revisions's algorithm.
+
+        Uses count_file_references for total, then subtracts the references
+        from the excluded documents.
+        """
+        if not file_ids:
+            return {}
+
+        total_refs = count_file_references(session, file_ids)
+
+        # Count references from excluded documents (DocumentRevision only).
+        exclude_chunk_size = max(1, MAX_PARAM_SIZE - QUERY_CHUNK_SIZE)
+        excluded_counts: dict = {}
+        for f_chunk in batched(file_ids, QUERY_CHUNK_SIZE):
+            for e_chunk in batched(exclude_doc_ids, exclude_chunk_size):
+                rows = (
+                    session.query(
+                        MDocumentRevision.file_id,
+                        func.count(MDocumentRevision.id),
+                    )
+                    .filter(MDocumentRevision.file_id.in_(list(f_chunk)))
+                    .filter(MDocumentRevision.document_id.in_(list(e_chunk)))
+                    .group_by(MDocumentRevision.file_id)
+                    .all()
+                )
+                for file_id, count in rows:
+                    excluded_counts[file_id] = excluded_counts.get(file_id, 0) + count
+
+        result = {}
+        for fid in file_ids:
+            total = total_refs.get(fid, 0)
+            excluded = excluded_counts.get(fid, 0)
+            result[fid] = max(0, total - excluded)
+        return result
+
+    def test_excluded_doc_does_not_block_deletion(self, session):
+        """A file referenced ONLY by an excluded document should have
+        other_count=0, meaning it is safe to delete."""
+        _seed(session, _file("f1"), _doc("d_excluded"), _rev("d_excluded", "f1"))
+
+        result = self._count_other_refs(session, ["f1"], ["d_excluded"])
+        assert result["f1"] == 0  # safe to delete
+
+    def test_other_doc_blocks_deletion(self, session):
+        """A file referenced by a non-excluded document should have
+        other_count > 0, blocking deletion."""
+        _seed(
+            session,
+            _file("f1"),
+            _doc("d_excluded"),
+            _doc("d_other"),
+            _rev("d_excluded", "f1"),
+            _rev("d_other", "f1"),
+        )
+
+        result = self._count_other_refs(session, ["f1"], ["d_excluded"])
+        assert result["f1"] == 1  # d_other still references it
+
+    def test_avatar_blocks_deletion(self, session):
+        """A file used as User.avatar_id should block deletion even if
+        all DocumentRevision references are excluded."""
+        _seed(
+            session,
+            _file("f1"),
+            _doc("d_excluded"),
+            _rev("d_excluded", "f1"),
+            _user("alice", avatar_id="f1"),
+        )
+
+        result = self._count_other_refs(session, ["f1"], ["d_excluded"])
+        # total = 2 (1 revision + 1 avatar), excluded = 1 → other = 1
+        assert result["f1"] == 1  # avatar blocks deletion
+
+    def test_cascade_task_does_not_block(self, session):
+        """file_tasks (CASCADE FK) should NOT block deletion, even if
+        many tasks exist for the file."""
+        _seed(
+            session,
+            _file("f1"),
+            _doc("d_excluded"),
+            _rev("d_excluded", "f1"),
+            _task("t1", "f1"),
+            _task("t2", "f1"),
+        )
+
+        result = self._count_other_refs(session, ["f1"], ["d_excluded"])
+        # total = 1 (revision only, tasks excluded), excluded = 1 → other = 0
+        assert result["f1"] == 0  # safe to delete
+
+    def test_multi_chunk_file_ids(self, session):
+        """Verify correct results when file_ids spans multiple chunks,
+        with a mix of deletable and non-deletable files."""
+        n = QUERY_CHUNK_SIZE + 20
+
+        objs = [_doc("d_excluded"), _doc("d_other")]
+
+        # First half: referenced only by excluded doc → should be deletable
+        deletable_ids = [f"del_{i:04d}" for i in range(n // 2)]
+        for fid in deletable_ids:
+            objs.extend([_file(fid), _rev("d_excluded", fid)])
+
+        # Second half: also referenced by d_other → should NOT be deletable
+        kept_ids = [f"kept_{i:04d}" for i in range(n // 2, n)]
+        for fid in kept_ids:
+            objs.extend([_file(fid), _rev("d_excluded", fid), _rev("d_other", fid)])
+
+        _seed(session, *objs)
+
+        all_ids = deletable_ids + kept_ids
+        result = self._count_other_refs(session, all_ids, ["d_excluded"])
+
+        for fid in deletable_ids:
+            assert result[fid] == 0, (
+                f"{fid} should be deletable but count={result[fid]}"
+            )
+        for fid in kept_ids:
+            assert result[fid] == 1, f"{fid} should be kept but count={result[fid]}"
+
+    def test_multi_chunk_exclude_doc_ids(self, session):
+        """Verify correct results when exclude_doc_ids exceeds the
+        exclude chunk size (MAX_PARAM_SIZE - QUERY_CHUNK_SIZE)."""
+        exclude_chunk = MAX_PARAM_SIZE - QUERY_CHUNK_SIZE
+        n_docs = exclude_chunk + 10  # force at least 2 chunks
+
+        objs = [_file("f1")]
+        doc_ids = []
+        for i in range(n_docs):
+            did = f"d_excl_{i:04d}"
+            doc_ids.append(did)
+            objs.extend([_doc(did), _rev(did, "f1")])
+        _seed(session, *objs)
+
+        result = self._count_other_refs(session, ["f1"], doc_ids)
+        # All references are from excluded docs → safe to delete
+        assert result["f1"] == 0


### PR DESCRIPTION
## Summary by Sourcery

Introduce centralized, reflected foreign-key–based file reference counting and integrate it into file deletion paths.

New Features:
- Add a reusable count_file_references utility that reflects foreign keys to the files table and counts references across all non-cascading relations.

Enhancements:
- Refactor document revision deletion and bulk purge logic to rely on centralized file reference counts with support for excluding specific documents, simplifying file deletability checks and removing avatar-specific counting helpers.
- Improve batch querying in bulk document purge and reference counting paths to respect bind-variable limits via chunked queries and shared chunk-size constants.

Tests:
- Add comprehensive unit tests for the new file reference counting utility, its caching behavior, chunking logic, and the total-minus-excluded pattern used for determining other references.