### PR TITLE
feat: add pepper for enhanced security in TOTP backup code hashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,7 @@ src/content/logs/*
 .idea
 uv.lock
 tests/*_old.py
+
+# Node.js
+package-lock.json
+package.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0.260513_alpha (2026-05-17)
+## 0.2.0.260517_alpha (2026-05-17)
 
 * feat: add `clear_totp.py` for maintenance purposes ([db06f9d](https://github.com/cfms-dev/cfms_on_websocket/commit/db06f9d))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## 0.2.0.260513_alpha (2026-05-17)
+
+* feat: add `clear_totp.py` for maintenance purposes ([db06f9d](https://github.com/cfms-dev/cfms_on_websocket/commit/db06f9d))
+
+### BREAKING CHANGES
+
+* Users' TOTP backup codes will be calculated and stored using the `argon2id` algorithm. This means that previously generated backup codes will become invalid and may throw two exceptions that are not designed to be caught during verification: `VerificationError` and `InvalidHashError`. Consider running `src\maintenance_scripts\clear_totp.py` immediately after the update to clear the two-step verification status for all users, allowing them to reset afterward.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 ### BREAKING CHANGES
 
 * Users' TOTP backup codes will be calculated and stored using the `argon2id` algorithm. This means that previously generated backup codes will become invalid and may throw two exceptions that are not designed to be caught during verification: `VerificationError` and `InvalidHashError`. Consider running `src\maintenance_scripts\clear_totp.py` immediately after the update to clear the two-step verification status for all users, allowing them to reset afterward.
+* The `pepper` parameter has been added to the configuration file to enhance security. Its value is not automatically set after server-side initialization. For security reasons, please remember to manually set it (this will affect the generation and verification behavior of recovery codes, so please ensure you complete the setting before enabling two-step verification).

--- a/src/config.toml.sample
+++ b/src/config.toml.sample
@@ -19,6 +19,7 @@ allow_name_duplicate = false
 # 但新上传的文档将会被拒绝
 
 [security]
+pepper = ""
 passwd_min_length = 8
 passwd_max_length = 32
 enable_passwd_force_expiration = true

--- a/src/include/conf_loader.py
+++ b/src/include/conf_loader.py
@@ -20,9 +20,6 @@ if __name__ == "__main__":
 if not os.path.exists("config.toml"):
     raise FileNotFoundError("Configuration file 'config.toml' not found.")
 
-with open("config.toml", "rb") as f:
-    global_config = tomllib.load(f)
-
 if not os.path.exists("init"):
     with open("config.toml", "r", encoding="utf-8") as f:
         toml_doc = parse(f.read())
@@ -35,3 +32,6 @@ if not os.path.exists("init"):
 
     with open("config.toml", "w", encoding="utf-8") as f:
         f.write(dumps(toml_doc))
+
+with open("config.toml", "rb") as f:
+    global_config = tomllib.load(f)

--- a/src/include/conf_loader.py
+++ b/src/include/conf_loader.py
@@ -28,7 +28,10 @@ if not os.path.exists("init"):
         toml_doc = parse(f.read())
 
     secret_key = secrets.token_hex(32)
-    toml_doc["server"]["secret_key"] = secret_key  # type: ignore
+    pepper = secrets.token_hex(32)
+
+    toml_doc["server"]["secret_key"] = secret_key  # pyright: ignore[reportIndexIssue]
+    toml_doc["security"]["pepper"] = pepper  # pyright: ignore[reportIndexIssue]
 
     with open("config.toml", "w", encoding="utf-8") as f:
         f.write(dumps(toml_doc))

--- a/src/include/constants.py
+++ b/src/include/constants.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from include.classes.version import Version
 
-CORE_VERSION = Version("0.2.0.260513_alpha")
+CORE_VERSION = Version("0.2.0.260517_alpha")
 PROTOCOL_VERSION = 13
 
 ROOT_ABSPATH = Path(__file__).resolve().parent.parent

--- a/src/include/database/models/classic.py
+++ b/src/include/database/models/classic.py
@@ -1,4 +1,3 @@
-import hashlib
 import secrets
 import time
 from functools import cached_property
@@ -232,10 +231,9 @@ class User(Base):
 
         # Generate 10 backup codes
         backup_codes = [secrets.token_hex(4) for _ in range(10)]
-        # Hash the backup codes before storing
-        hashed_codes = [
-            hashlib.sha256(code.encode("utf-8")).hexdigest() for code in backup_codes
-        ]
+        pepper = global_config.get("security", {}).get("pepper", "")
+        # Hash the backup codes before storing using Argon2id with pepper
+        hashed_codes = [_password_hasher.hash(code + pepper) for code in backup_codes]
         self.totp_backup_codes = orjson.dumps(hashed_codes).decode("utf-8")
 
         # TOTP is not enabled yet until validated
@@ -295,19 +293,25 @@ class User(Base):
         if self.totp_enabled and self.totp_backup_codes:
             try:
                 hashed_codes = orjson.loads(self.totp_backup_codes)
-                token_hash = hashlib.sha256(token.encode("utf-8")).hexdigest()
+                pepper = global_config.get("security", {}).get("pepper", "")
 
-                if token_hash in hashed_codes:
-                    # Remove the used backup code
-                    hashed_codes.remove(token_hash)
-                    self.totp_backup_codes = orjson.dumps(hashed_codes).decode("utf-8")
+                for hash_str in hashed_codes:
+                    try:
+                        if _password_hasher.verify(hash_str, token + pepper):
+                            # Verification succeeded, remove the used backup code
+                            hashed_codes.remove(hash_str)
+                            self.totp_backup_codes = orjson.dumps(hashed_codes).decode(
+                                "utf-8"
+                            )
 
-                    session = object_session(self)
-                    if session is not None:
-                        session.add(self)
-                        session.commit()
+                            session = object_session(self)
+                            if session is not None:
+                                session.add(self)
+                                session.commit()
 
-                    return True
+                            return True
+                    except VerifyMismatchError:
+                        continue
             except (orjson.JSONDecodeError, ValueError):
                 pass
 

--- a/src/include/database/models/classic.py
+++ b/src/include/database/models/classic.py
@@ -231,7 +231,7 @@ class User(Base):
 
         # Generate 10 backup codes
         backup_codes = [secrets.token_hex(4) for _ in range(10)]
-        pepper = global_config.get("security", {}).get("pepper", "")
+        pepper = global_config["security"]["pepper"]
         # Hash the backup codes before storing using Argon2id with pepper
         hashed_codes = [_password_hasher.hash(code + pepper) for code in backup_codes]
         self.totp_backup_codes = orjson.dumps(hashed_codes).decode("utf-8")
@@ -293,7 +293,7 @@ class User(Base):
         if self.totp_enabled and self.totp_backup_codes:
             try:
                 hashed_codes = orjson.loads(self.totp_backup_codes)
-                pepper = global_config.get("security", {}).get("pepper", "")
+                pepper = global_config["security"]["pepper"]
 
                 for hash_str in hashed_codes:
                     try:

--- a/src/main.py
+++ b/src/main.py
@@ -382,6 +382,14 @@ def main():
             f"against CA path '{client_ca_path}'."
         )
 
+    if not security_cfg["pepper"]:
+        logger.warning(
+            "Setting the value for `pepper` to empty in the configuration "
+            "file can lead to potential security vulnerabilities. For "
+            "details, see: https://cheatsheetseries.owasp.org/cheatsheets/"
+            "Password_Storage_Cheat_Sheet.html#peppering"
+        )
+
     if ssl.OPENSSL_VERSION_INFO < (3, 5):
         logger.warning(
             "The version of OpenSSL bundled with Python is too low "

--- a/src/maintenance_scripts/clear_totp.py
+++ b/src/maintenance_scripts/clear_totp.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+clear_totp.py - CFMS maintenance script
+
+Clears the TOTP (Two-Factor Authentication) state for users in the database.
+
+Usage:
+    # Clear for all users:
+    python clear_totp.py --all
+
+    # Or, clear for a specific user:
+    python clear_totp.py <username>
+
+This script must be run from the `src/` directory (same working directory as
+`main.py`) so that `config.toml` and the database path are resolved
+correctly.
+"""
+
+import argparse
+import os
+import sys
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, parent_dir)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Clear TOTP state for CFMS users from the command line."
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "username", nargs="?", help="Username whose TOTP state should be cleared"
+    )
+    group.add_argument(
+        "--all",
+        action="store_true",
+        help="Clear TOTP state for ALL users in the database",
+    )
+    args = parser.parse_args()
+
+    # Validate that the caller is running from the src/ directory so that
+    # conf_loader and the database can be found.
+    if not os.path.exists("config.toml"):
+        print(
+            "Error: 'config.toml' not found in the current directory.\n"
+            "Please run this script from the 'src/' directory.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Late imports so that the path check above can produce a clean error before
+    # the import machinery tries to load config.toml.
+    from include.database.handler import Session  # noqa: F401
+    from include.database.models.classic import User  # noqa: F401
+    from include.database.models.entity import (  # noqa: F401
+        Document,
+        DocumentRevision,
+        Folder,
+    )
+    from include.database.models.file import File, FileTask  # noqa: F401
+    from include.database.models.keyring import UserKey  # noqa: F401
+
+    with Session() as session:
+        if args.all:
+            # Clear for all users
+            updated_count = session.query(User).update(
+                {
+                    User.totp_enabled: False,
+                    User.totp_secret: None,
+                    User.totp_backup_codes: None,
+                }
+            )
+            session.commit()
+            print(f"Successfully cleared TOTP state for all {updated_count} user(s).")
+        else:
+            # Clear for a specific user
+            username = args.username
+            user = session.get(User, username)
+            if user is None:
+                print(f"Error: User '{username}' not found.", file=sys.stderr)
+                sys.exit(1)
+
+            user.totp_enabled = False
+            user.totp_secret = None
+            user.totp_backup_codes = None
+            session.add(user)
+            session.commit()
+            print(f"Successfully cleared TOTP state for user '{username}'.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/maintenance_scripts/fill_pepper.py
+++ b/src/maintenance_scripts/fill_pepper.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+fill_pepper.py - CFMS maintenance script
+
+Automatically generates and fills in the `pepper` field in the [security] section
+of the `config.toml` file, if it is currently empty or not present.
+
+Usage:
+    python maintenance_scripts/fill_pepper.py
+
+This script must be run from the `src/` directory (same working directory as
+`main.py`) so that `config.toml` is resolved correctly.
+"""
+
+import os
+import secrets
+import sys
+from typing import cast
+
+try:
+    import tomlkit
+except ImportError:
+    print(
+        "Error: 'tomlkit' package is not installed.\n"
+        "Please install it using 'pip install tomlkit' or ensure you are in the correct virtual environment.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+def main() -> None:
+    # Ensure the script is run from the src/ directory or it can find config.toml
+    config_path = "config.toml"
+
+    if not os.path.exists(config_path):
+        print(
+            "Error: 'config.toml' not found in the current directory.\n"
+            "Please run this script from the 'src/' directory.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            doc = tomlkit.load(f)
+    except Exception as e:
+        print(f"Error reading {config_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Ensure [security] section exists
+    if "security" not in doc:
+        print(f"Adding [security] section to {config_path}")
+        doc.add("security", tomlkit.table())
+
+    security_section = cast(dict, doc["security"])
+
+    # Check if pepper exists and has a value
+    if "pepper" not in security_section or not security_section["pepper"]:
+        # Generate a 32-byte cryptographically secure random string in hex format
+        new_pepper = secrets.token_hex(32)
+        security_section["pepper"] = new_pepper
+
+        try:
+            with open(config_path, "w", encoding="utf-8") as f:
+                tomlkit.dump(doc, f)
+            print(f"Successfully generated and filled 'pepper' in {config_path}")
+        except Exception as e:
+            print(f"Error writing to {config_path}: {e}", file=sys.stderr)
+            sys.exit(1)
+    else:
+        print(f"The 'pepper' field is already set in {config_path}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary by Sourcery

Strengthen TOTP backup code storage and verification by switching to peppered Argon2id hashes and wiring the pepper into configuration.

New Features:
- Introduce a configurable security pepper used when hashing TOTP backup codes.
- Generate and persist a random security pepper in the configuration file during initial setup.

Enhancements:
- Replace SHA-256 with Argon2id for hashing TOTP backup codes and update verification logic to use the new hashing scheme while preserving one-time use behavior.