### PR TITLE
Refactor connection handling, implement FIFO queue, and enhance documentation

### DIFF
--- a/src/include/config/version.py
+++ b/src/include/config/version.py
@@ -15,12 +15,12 @@ class Version:
             r"(?:_([a-zA-Z]+)"  # optional _type
             r"(\d*)?)?"  # optional type_num
         )
-        # 版本号正则说明：
-        # (\d+)         匹配主版本号
-        # \.(\d+)       匹配次版本号
-        # \.(\d+)       匹配修订号
-        # (?:\.(\d+))?  可选的构建号
-        # (?:_([a-zA-Z]+)(\d*)?)? 可选的类型及其编号
+        # Version pattern groups:
+        # (\d+) matches the major version.
+        # \.(\d+) matches the minor version.
+        # \.(\d+) matches the patch version.
+        # (?:\.(\d+))? optionally matches the build number.
+        # (?:_([a-zA-Z]+)(\d*)?)? optionally matches type and type number.
         match = re.match(version_pattern, version_str)
         if not match:
             raise ValueError(f"Invalid version string: {version_str}")
@@ -31,8 +31,8 @@ class Version:
         self.type = match.group(5) or ""
         self.type_num = int(match.group(6)) if match.group(6) else 0
 
-        # type_order 字典用于定义版本类型的优先级，数值越小优先级越高。
-        # 优先级分配如下：release 和未指定类型优先级最高（0），
+        # Lower values indicate higher version type precedence.
+        # Release and unspecified types have the highest precedence.
         self.type_order = {"release": 0, "": 0, "rc": 1, "beta": 2, "alpha": 3}
 
     def _cmp_tuple(self):

--- a/src/include/database/models/documents.py
+++ b/src/include/database/models/documents.py
@@ -259,20 +259,20 @@ class DocumentRevisionStatus(IntEnum):
     DELETED = 1
 
 
-class Folder(BaseObject):  # 文档文件夹
+class Folder(BaseObject):  # Document folder.
     __tablename__ = "folders"
     id: Mapped[str] = mapped_column(
         VARCHAR(255), primary_key=True, default=lambda: secrets.token_hex(32)
     )
     name: Mapped[str] = mapped_column(
         VARCHAR(255), nullable=False, index=True
-    )  # 文件夹名称
+    )  # Folder name.
     created_time: Mapped[float] = mapped_column(
         Float, nullable=False, default=lambda: time.time()
     )
     parent_id: Mapped[Optional[str]] = mapped_column(
         VARCHAR(255), ForeignKey("folders.id", ondelete="CASCADE")
-    )  # 父文件夹ID
+    )  # Parent folder ID.
     parent: Mapped[Optional["Folder"]] = relationship(
         "Folder", back_populates="children", remote_side=[id]
     )
@@ -328,18 +328,18 @@ class Document(BaseObject):
     )
     title: Mapped[str] = mapped_column(
         VARCHAR(255), nullable=False, default="Untitled Document", index=True
-    )  # 文档名称
+    )  # Document name.
     created_time: Mapped[float] = mapped_column(
         Float, nullable=False, default=lambda: time.time()
     )
     folder_id: Mapped[Optional[str]] = mapped_column(
         VARCHAR(255), ForeignKey("folders.id", ondelete="CASCADE"), nullable=True
-    )  # 文档所属文件夹ID
+    )  # Folder ID that owns the document.
     folder: Mapped[Optional["Folder"]] = relationship(
         "Folder", back_populates="documents"
     )
 
-    # 每个文档有多个访问规则（AccessRule对象），以JSON格式存储规则数据
+    # Each document has multiple access rules with rule data stored as JSON.
     access_rules: Mapped[List["DocumentAccessRule"]] = relationship(
         "DocumentAccessRule", back_populates="document", cascade="all, delete-orphan"
     )
@@ -360,14 +360,14 @@ class Document(BaseObject):
         uselist=False,
     )
 
-    # 每个文档有多个修订版本
+    # Each document has multiple revisions.
     revisions: Mapped[List["DocumentRevision"]] = relationship(
         "DocumentRevision",
         back_populates="document",
         foreign_keys="[DocumentRevision.document_id]",
         order_by="DocumentRevision.created_time",
         cascade="all, delete-orphan",
-        overlaps="current_revision",  # 声明与 current_revision 的重叠
+        overlaps="current_revision",  # Declares overlap with current_revision.
     )
     inherit: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     metadata_record: Mapped[Optional["DocumentMetadata"]] = relationship(
@@ -387,12 +387,13 @@ class Document(BaseObject):
 
     def get_latest_revision(self) -> "DocumentRevision":
         """
-        获取最新的活跃修订版本。
+        Return the latest active revision.
 
-        该函数的逻辑如下：
-
-        - 如果 current_revision 不为空，则从指定的 current_revision 开始，寻找从修订版本树末端上溯遇到的第一个活跃修订版本。
-        - 如果 current_revision 为空（这一般仅在从过去的版本升级时发生），则将全体修订版本按`created_time`降序排列，返回第一个`revision.active`为`True`的修订版本。
+        If current_revision is set, walk upward from it and return the first
+        active revision found in that branch. If current_revision is not set,
+        which generally only occurs after upgrading from an older version,
+        sort all revisions by created_time descending and return the first
+        revision whose active property is True.
         """
         current_revision = self.current_revision
         if current_revision is not None:
@@ -413,7 +414,7 @@ class Document(BaseObject):
         if not revisions:
             raise RuntimeError("A document cannot have no revisions.")
 
-        # 过滤出active为True的修订版本
+        # Keep only revisions whose active property is True.
         active_revisions = [rev for rev in revisions if rev.active]
 
         if not active_revisions:
@@ -521,7 +522,7 @@ class DocumentRevision(Base):
         "Document",
         back_populates="revisions",
         foreign_keys=[document_id],
-        overlaps="current_revision",  # 声明重叠
+        overlaps="current_revision",  # Declares overlap.
     )
     file: Mapped["File"] = relationship(
         "File", primaryjoin="DocumentRevision.file_id == File.id"
@@ -590,7 +591,7 @@ class DocumentAccessRule(Base, AccessRuleBase):
     )
     rule_data: Mapped[dict] = mapped_column(
         JSON, nullable=False
-    )  # 存储单个Json格式的规则数据
+    )  # Stores a single JSON rule object.
 
     document: Mapped[Optional["Document"]] = relationship(
         "Document", back_populates="access_rules"
@@ -613,7 +614,7 @@ class FolderAccessRule(Base, AccessRuleBase):
     )
     rule_data: Mapped[dict] = mapped_column(
         JSON, nullable=False
-    )  # 存储单个Json格式的规则数据
+    )  # Stores a single JSON rule object.
 
     folder: Mapped[Optional["Folder"]] = relationship(
         "Folder", back_populates="access_rules"

--- a/src/include/database/models/files.py
+++ b/src/include/database/models/files.py
@@ -174,7 +174,9 @@ class File(Base):
 
     def get_latest_task(self):
         """
-        返回最后一个尚未结束（也包括尚未开始）的任务，按起始时间排序。
+        Return the latest task that has not ended, including tasks not yet started.
+
+        Tasks are ordered by their start time.
         """
 
         now = time.time()
@@ -202,7 +204,7 @@ class FileTask(Base):
     file_id: Mapped[str] = mapped_column(
         VARCHAR(255), ForeignKey("files.id", ondelete="CASCADE"), nullable=False
     )
-    # 0: 等待中, 1: 已完成, 2: 已取消
+    # 0: pending, 1: completed, 2: cancelled.
     status: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
     mode: Mapped[int] = mapped_column(
         Integer, nullable=False, comment="0: download, 1: upload"
@@ -225,7 +227,7 @@ class FileTask(Base):
 
     # encryption_mode: Mapped[Optional[str]] = mapped_column(
     #     VARCHAR(32), nullable=True, default=None
-    # )  # 加密模式，如 'AES', 'RSA'，未加密则为 None
+    # )  # Encryption mode, such as 'AES' or 'RSA'; None means unencrypted.
 
     file: Mapped["File"] = relationship("File", back_populates="tasks")
 

--- a/src/include/database/models/identity.py
+++ b/src/include/database/models/identity.py
@@ -115,8 +115,9 @@ class User(Base):
         Integer, default=UserStatus.ACTIVE.value, nullable=False
     )
 
-    # 这是对应每个用户的 secret_key. 每次更改密码时将重新生成，如果该属性不为空，则在验证 token 时使用此
-    # 密钥，否则，使用从 config.toml 加载的全局密钥。
+    # Per-user secret key. It is regenerated whenever the password changes.
+    # Token verification uses it when present; otherwise it falls back to the
+    # global secret key loaded from config.toml.
     secret_key: Mapped[str] = mapped_column(
         VARCHAR(64), default=lambda: secrets.token_hex(32), nullable=True
     )
@@ -225,8 +226,10 @@ class User(Base):
 
     def is_token_valid(self, token: str) -> bool:
         """
-        验证JWT令牌的有效性。
-        如果令牌有效且未过期，且用户账户处于活跃状态，返回True；否则返回False。
+        Validate a JWT for this user.
+
+        Return True when the token is valid, unexpired, and the user account is
+        active; otherwise return False.
         """
         if self.status != UserStatus.ACTIVE:
             return False
@@ -245,9 +248,7 @@ class User(Base):
             return False
 
     def renew_token(self) -> Token:
-        """
-        重新生成用户的JWT令牌。
-        """
+        """Regenerate this user's JWT."""
 
         secret = (
             global_config["server"]["secret_key"]
@@ -260,9 +261,7 @@ class User(Base):
         return new_token
 
     def set_password(self, plain_password: str, force_update_after_login: bool = False):
-        """
-        修改用户密码，使用 argon2id KDF 生成哈希并保存，写入数据库。
-        """
+        """Update the user's password and persist an Argon2id hash."""
         self.pass_hash = _password_hasher.hash(plain_password)
 
         self.secret_key = secrets.token_hex(
@@ -270,7 +269,7 @@ class User(Base):
         )  # token_hex(32) generates a 64-character hex
         self.passwd_last_modified = time.time() if not force_update_after_login else 0
 
-        # 写入数据库
+        # Write to the database.
         session = object_session(self)
         if session is not None:
             session.add(self)
@@ -385,9 +384,7 @@ class User(Base):
 
     @property
     def all_groups(self):
-        """
-        获取用户所有有效的用户组名称集合。
-        """
+        """Return the set of currently active group names for this user."""
         now = time.time()
         return {
             membership.group_name
@@ -490,7 +487,7 @@ class User(Base):
         return (all_perms - revoked_perms) if (all_perms or revoked_perms) else set()
 
 
-# 用户权限表，支持权限的给予/剥夺及持续时间
+# User permission table with grants, revocations, and validity windows.
 class UserPermission(Base):
     __tablename__ = "user_permissions"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -500,13 +497,13 @@ class UserPermission(Base):
     permission: Mapped[Permissions] = mapped_column(VARCHAR(255))
     granted: Mapped[bool] = mapped_column(
         Boolean, default=True
-    )  # True: 给予, False: 剥夺
+    )  # True grants the permission; False revokes it.
     start_time: Mapped[Optional[float]] = mapped_column(
         Float, nullable=False
-    )  # 权限生效时间（时间戳）
+    )  # Permission start timestamp.
     end_time: Mapped[Optional[float]] = mapped_column(
         Float, nullable=True
-    )  # 权限失效时间（时间戳）
+    )  # Permission end timestamp.
     user: Mapped["User"] = relationship("User", back_populates="rights")
 
     def __repr__(self) -> str:
@@ -520,12 +517,12 @@ class UserPermission(Base):
 @event.listens_for(User, "load")
 def filter_permissions_on_load(target, context):
     now = time.time()
-    # 只保留granted=True且未过期的权限
+    # Keep only granted permissions that have not expired.
     valid_permissions = []
     session = object_session(target)
     for perm in list(target.rights):
         if not perm.granted or (perm.end_time is not None and perm.end_time < now):
-            # 从数据库中永久删除过期或被剥夺的权限
+            # Permanently delete expired or revoked permissions from the DB.
             if session is not None:
                 session.delete(perm)
         else:
@@ -533,7 +530,7 @@ def filter_permissions_on_load(target, context):
     target.rights = valid_permissions
 
 
-# 用户所属组，包括在此用户组中的持续时间
+# User group memberships with validity windows.
 class UserMembership(Base):
     __tablename__ = "user_memberships"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -543,10 +540,10 @@ class UserMembership(Base):
     group_name: Mapped[str] = mapped_column(
         ForeignKey("user_groups.group_name", ondelete="CASCADE")
     )
-    start_time: Mapped[float] = mapped_column(Float, nullable=False)  # 加入组的时间戳
+    start_time: Mapped[float] = mapped_column(Float, nullable=False)  # Join timestamp.
     end_time: Mapped[Optional[float]] = mapped_column(
         Float, nullable=True
-    )  # 离开组的时间戳
+    )  # Leave timestamp.
     user: Mapped["User"] = relationship("User", back_populates="groups")
     group: Mapped["UserGroup"] = relationship("UserGroup", back_populates="memberships")
 
@@ -562,7 +559,7 @@ class UserMembership(Base):
 def filter_expired_group(user, group, initiator):
     now = time.time()
     if group.end_time is not None and group.end_time < now:
-        return None  # 不添加
+        return None  # Do not append.
     return group
 
 
@@ -628,7 +625,7 @@ class UserGroup(Base):
         )
 
 
-# 用户组权限表，支持权限的给予/剥夺及持续时间
+# Group permission table with grants, revocations, and validity windows.
 class UserGroupPermission(Base):
     __tablename__ = "group_permissions"
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
@@ -638,13 +635,13 @@ class UserGroupPermission(Base):
     permission: Mapped[str] = mapped_column(VARCHAR(255))
     granted: Mapped[bool] = mapped_column(
         Boolean, default=True
-    )  # True: 给予, False: 剥夺
+    )  # True grants the permission; False revokes it.
     start_time: Mapped[Optional[float]] = mapped_column(
         Float, nullable=False, default=0.0
-    )  # 权限生效时间（时间戳）
+    )  # Permission start timestamp.
     end_time: Mapped[Optional[float]] = mapped_column(
         Float, nullable=True
-    )  # 权限失效时间（时间戳）
+    )  # Permission end timestamp.
     group: Mapped["UserGroup"] = relationship("UserGroup", back_populates="permissions")
 
     def __repr__(self) -> str:

--- a/src/include/domains/access/authorization/searchable_tree.py
+++ b/src/include/domains/access/authorization/searchable_tree.py
@@ -14,33 +14,32 @@ from include.database.models.access import ObjectAccessEntry
 from include.database.models.documents import Document, Folder
 
 
-# ── 内部辅助：给定起始 folder_id 集合和需要查OAE的目标ID集合，
-#    批量展开祖先链、预加载权限数据 ──────────────────────────────────────────
+# Internal helper: expand ancestor chains and preload permission data for the
+# starting folder IDs and target IDs that require OAE lookup.
 def _fetch_ancestors_and_oae(
     session: Session,
-    seed_folder_ids: list[str],  # CTE 递归的起点文件夹 ID 集合
-    extra_target_ids: list[str],  # 除文件夹外还需要查 OAE 的其他目标ID（如文档ID）
-    exclude_folder_ids: set[
-        str
-    ],  # 已经加载过的文件夹ID，不需要重复查（如命中的文件夹自身）
+    seed_folder_ids: list[str],  # Starting folder IDs for the recursive CTE.
+    extra_target_ids: list[str],  # Non-folder target IDs requiring OAE lookup.
+    exclude_folder_ids: set[str],  # Folder IDs already loaded and not queried again.
     now: float,
 ) -> tuple[list[Folder], dict]:
     """
-    公共内部函数：
-    1. 用递归 CTE 从 seed_folder_ids 出发，展开所有祖先文件夹
-    2. 批量加载这些文件夹（含 access_rules 预加载），排除 exclude_folder_ids
-    3. 批量拉取 extra_target_ids + 所有祖先文件夹 的 ObjectAccessEntry
+    Expand ancestors and preload access data.
 
-    返回：
-        ancestor_folders - 祖先文件夹列表（已排除 exclude_folder_ids）
-        oae_by_target    - Dict[target_id, List[ObjectAccessEntry]]
+    The recursive CTE starts from seed_folder_ids, loads ancestor folders with
+    access_rules preloaded while excluding exclude_folder_ids, and fetches
+    ObjectAccessEntry rows for extra_target_ids plus all ancestor folders.
+
+    Returns:
+        ancestor_folders: Ancestor folders excluding exclude_folder_ids.
+        oae_by_target: Dict[target_id, List[ObjectAccessEntry]].
     """
     if not seed_folder_ids:
-        # 没有任何祖先需要查（比如所有文档都在根目录）
+        # No ancestors need lookup, such as when all documents are in root.
         all_target_ids = extra_target_ids
         ancestor_folders = []
     else:
-        # Step A：递归 CTE 展开所有祖先 ID（自动去重）
+        # Step A: Expand all ancestor IDs with a recursive CTE and deduplicate.
         placeholders = ", ".join(f":fid_{i}" for i in range(len(seed_folder_ids)))
         params = {f"fid_{i}": fid for i, fid in enumerate(seed_folder_ids)}
 
@@ -63,7 +62,8 @@ def _fetch_ancestors_and_oae(
             row[0] for row in session.execute(ancestor_sql, params).fetchall()
         ]
 
-        # Step B：排除已加载的，批量加载祖先 Folder（含 access_rules）
+        # Step B: Exclude already loaded IDs and bulk-load ancestor folders with
+        # access_rules.
         pure_ancestor_ids = [
             fid for fid in all_ancestor_ids if fid not in exclude_folder_ids
         ]
@@ -81,7 +81,7 @@ def _fetch_ancestors_and_oae(
 
         all_target_ids = extra_target_ids + all_ancestor_ids
 
-    # Step C：批量拉取 OAE（文档 + 所有文件夹，一次查询）
+    # Step C: Fetch OAE rows in bulk for documents and folders.
     oae_by_target: dict = defaultdict(list)
     if all_target_ids:
         oae_entries = (
@@ -100,24 +100,24 @@ def _fetch_ancestors_and_oae(
     return ancestor_folders, oae_by_target
 
 
-# ── 搜索文档 ────────────────────────────────────────────────────────────────
+# Document search.
 def search_documents_with_access(
     session: Session,
     keyword: str,
     now: Optional[float] = None,
 ) -> tuple[list[Document], list[Folder], dict]:
     """
-    按关键词搜索文档标题，批量预取祖先链权限信息。
+    Search document titles by keyword and preload ancestor access data.
 
-    返回：
-        documents     - 命中的文档列表（access_rules 已预加载）
-        folders       - 所有祖先文件夹列表（access_rules 已预加载）
-        oae_by_target - Dict[target_id, List[ObjectAccessEntry]]
+    Returns:
+        documents: Matched documents with access_rules preloaded.
+        folders: All ancestor folders with access_rules preloaded.
+        oae_by_target: Dict[target_id, List[ObjectAccessEntry]].
     """
     if now is None:
         now = time.time()
 
-    # Step 1：搜索文档
+    # Step 1: Search documents.
     documents = (
         session.query(Document)
         .options(joinedload(Document.access_rules))
@@ -127,39 +127,40 @@ def search_documents_with_access(
     if not documents:
         return [], [], {}
 
-    # Step 2：收集起点 folder_id（文档的直接父文件夹，去重）
+    # Step 2: Collect direct parent folder IDs as deduplicated CTE seeds.
     seed_folder_ids = list({doc.folder_id for doc in documents if doc.folder_id})
 
-    # Step 3-5：交给公共函数处理
+    # Steps 3-5: Delegate to the shared helper.
     ancestor_folders, oae_by_target = _fetch_ancestors_and_oae(
         session=session,
         seed_folder_ids=seed_folder_ids,
-        extra_target_ids=[doc.id for doc in documents],  # 文档本身也需要查 OAE
-        exclude_folder_ids=set(),  # 文档搜索时没有预加载过任何文件夹
+        extra_target_ids=[doc.id for doc in documents],  # Documents also need OAE.
+        exclude_folder_ids=set(),  # No folders are preloaded for document search.
         now=now,
     )
 
     return documents, ancestor_folders, oae_by_target
 
 
-# ── 搜索文件夹 ──────────────────────────────────────────────────────────────
+# Folder search.
 def search_folders_with_access(
     session: Session,
     keyword: str,
     now: Optional[float] = None,
 ) -> tuple[list[Folder], list[Folder], dict]:
     """
-    按关键词搜索文件夹名称，批量预取祖先链权限信息。
+    Search folder names by keyword and preload ancestor access data.
 
-    返回：
-        matched_folders  - 命中的文件夹列表（access_rules 已预加载）
-        ancestor_folders - 所有祖先文件夹列表（access_rules 已预加载，不含命中的）
-        oae_by_target    - Dict[target_id, List[ObjectAccessEntry]]
+    Returns:
+        matched_folders: Matched folders with access_rules preloaded.
+        ancestor_folders: Ancestor folders with access_rules preloaded,
+            excluding matched folders.
+        oae_by_target: Dict[target_id, List[ObjectAccessEntry]].
     """
     if now is None:
         now = time.time()
 
-    # Step 1：搜索文件夹
+    # Step 1: Search folders.
     matched_folders = (
         session.query(Folder)
         .options(joinedload(Folder.access_rules))
@@ -169,18 +170,18 @@ def search_folders_with_access(
     if not matched_folders:
         return [], [], {}
 
-    # Step 2：收集起点 parent_id（命中文件夹的直接父级，去重）
-    #         注意：命中的文件夹本身已加载，起点从它们的 parent_id 开始向上
+    # Step 2: Collect direct parent IDs as deduplicated seeds. Matched folders
+    # are already loaded, so traversal starts from their parent_id.
     seed_folder_ids = list({f.parent_id for f in matched_folders if f.parent_id})
 
     matched_ids = {f.id for f in matched_folders}
 
-    # Step 3-5：交给公共函数处理
-    #           exclude_folder_ids=matched_ids 避免重复加载命中的文件夹
+    # Steps 3-5: Delegate to the shared helper. Exclude matched_ids to avoid
+    # loading matched folders twice.
     ancestor_folders, oae_by_target = _fetch_ancestors_and_oae(
         session=session,
         seed_folder_ids=seed_folder_ids,
-        extra_target_ids=[f.id for f in matched_folders],  # 命中文件夹本身也需要查 OAE
+        extra_target_ids=[f.id for f in matched_folders],  # Matched folders need OAE.
         exclude_folder_ids=matched_ids,
         now=now,
     )

--- a/src/include/domains/access/permissions.py
+++ b/src/include/domains/access/permissions.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 
 
 class Permissions(StrEnum):
-    # 文件与目录操作
+    # File and directory operations
     MOVE = "move"
     CREATE_DOCUMENT = "create_document"
     DELETE_DOCUMENT = "delete_document"
@@ -20,14 +20,14 @@ class Permissions(StrEnum):
     RESTORE = "restore"
     """permission to restore documents/directories from deletion."""
 
-    # 超级权限操作 (Super)
+    # Super operations
     SUPER_CREATE_DOCUMENT = "super_create_document"
     SUPER_CREATE_DIRECTORY = "super_create_directory"
     SUPER_LIST_DIRECTORY = "super_list_directory"
     SUPER_SET_PASSWD = "super_set_passwd"
     SUPER_SET_USER_AVATAR = "super_set_user_avatar"
 
-    # 系统与管理
+    # System and management
     SHUTDOWN = "shutdown"
     MANAGE_SYSTEM = "manage_system"
     """
@@ -36,7 +36,7 @@ class Permissions(StrEnum):
     """
     DEBUGGING = "debugging"
 
-    # 用户管理
+    # User management
     CREATE_USER = "create_user"
     DELETE_USER = "delete_user"
     RENAME_USER = "rename_user"
@@ -47,7 +47,7 @@ class Permissions(StrEnum):
     SET_PASSWD = "set_passwd"
     SET_USER_PERMISSIONS = "set_user_permissions"
 
-    # 组管理
+    # Group management
     CREATE_GROUP = "create_group"
     DELETE_GROUP = "delete_group"
     RENAME_GROUP = "rename_group"
@@ -56,7 +56,7 @@ class Permissions(StrEnum):
     CHANGE_USER_GROUPS = "change_user_groups"
     SET_GROUP_PERMISSIONS = "set_group_permissions"
 
-    # 访问控制与锁定
+    # Access control and lockdown
     VIEW_ACCESS_RULES = "view_access_rules"
     SET_ACCESS_RULES = "set_access_rules"
     VIEW_METADATA = "view_metadata"
@@ -69,12 +69,12 @@ class Permissions(StrEnum):
     UNBLOCK = "unblock"
     LIST_USER_BLOCKS = "list_user_blocks"
 
-    # 日志与版本控制
+    # Logs and version control
     VIEW_AUDIT_LOGS = "view_audit_logs"
     LIST_REVISIONS = "list_revisions"
     VIEW_REVISION = "view_revision"
     SET_CURRENT_REVISION = "set_current_revision"
     DELETE_REVISION = "delete_revision"
 
-    # 密钥管理
+    # Key management
     MANAGE_KEYRINGS = "manage_keyrings"

--- a/src/include/domains/documents/commands/bulk_purge.py
+++ b/src/include/domains/documents/commands/bulk_purge.py
@@ -19,13 +19,15 @@ from include.domains.documents.queries.revisions import batch_count_other_revisi
 
 def purge_documents_bulk(session: Session, document_ids: List[str]):
     """
-    高度优化的批量粉碎函数。
-    将原本 600+ 次的单个文档删除，转化为针对所有文档的一组批量删除。
+    Purge many documents using batched deletes.
+
+    This converts hundreds of per-document deletes into a small set of bulk
+    operations across all target documents.
     """
     if not document_ids:
         return
 
-    # 1. 批量获取所有受影响的修订版本 ID 和文件 ID（分块查询以避免超出绑定变量限制）
+    # 1. Fetch affected revision IDs and file IDs in chunks to avoid bind limits.
     revision_data = []
     for chunk in batched(document_ids, QUERY_CHUNK_SIZE):
         revision_data.extend(
@@ -35,7 +37,7 @@ def purge_documents_bulk(session: Session, document_ids: List[str]):
         )
 
     if not revision_data:
-        # 如果这些文档都没有修订版本，直接删除文档记录即可
+        # If none of these documents have revisions, delete document rows only.
         for chunk in batched(document_ids, QUERY_CHUNK_SIZE):
             session.query(DocumentAccessRule).filter(
                 DocumentAccessRule.document_id.in_(chunk)
@@ -49,17 +51,16 @@ def purge_documents_bulk(session: Session, document_ids: List[str]):
     rev_ids = [r[0] for r in revision_data]
     file_ids = {r[1] for r in revision_data if r[1]}
 
-    # 2. 批量引用计数检查
-    # 使用集中计数，排除来自这批文档的引用后若为 0 则可删除
+    # 2. Count references in bulk. Files with no remaining external references
+    # can be deleted.
     other_counts = batch_count_other_revisions(session, list(file_ids), document_ids)
 
-    # 找出仅被这批文档引用、可以物理删除的文件 ID
+    # Find files referenced only by this batch and eligible for physical delete.
     deletable_file_ids = [fid for fid in file_ids if other_counts.get(fid, 0) == 0]
 
-    # 3. 批量删除 (使用 SQL 级别的 delete)
-    # 我们处于 no_autoflush 模式下运行此块
+    # 3. Delete in bulk using SQL-level deletes under no_autoflush.
 
-    # 3a. 先解除文档与修订版本、修订版本之间的外键引用
+    # 3a. Clear document-to-revision and revision-to-revision FK references.
     for chunk in batched(document_ids, QUERY_CHUNK_SIZE):
         session.query(Document).filter(Document.id.in_(chunk)).update(
             {Document.current_revision_id: None}, synchronize_session=False
@@ -70,20 +71,20 @@ def purge_documents_bulk(session: Session, document_ids: List[str]):
             {DocumentRevision.parent_revision_id: None}, synchronize_session=False
         )
 
-    # 3b. 清理相关任务
+    # 3b. Clean up related tasks.
     if deletable_file_ids:
         for chunk in batched(deletable_file_ids, QUERY_CHUNK_SIZE):
             session.query(FileTask).filter(FileTask.file_id.in_(chunk)).delete(
                 synchronize_session=False
             )
 
-    # 3c. 收集文件路径。File 记录必须等 DocumentRevision 删除后才能删除。
+    # 3c. Collect file paths. File rows must be deleted after revisions.
     deletable_files = []
     if deletable_file_ids:
         for chunk in batched(deletable_file_ids, QUERY_CHUNK_SIZE):
             deletable_files.extend(session.query(File).filter(File.id.in_(chunk)).all())
 
-    # 3d. 批量删除修订版本、文件和文档
+    # 3d. Delete revisions, files, and documents in bulk.
     for chunk in batched(rev_ids, QUERY_CHUNK_SIZE):
         session.query(DocumentRevision).filter(DocumentRevision.id.in_(chunk)).delete(
             synchronize_session=False

--- a/src/include/domains/documents/handlers/directories.py
+++ b/src/include/domains/documents/handlers/directories.py
@@ -320,7 +320,7 @@ class RequestGetDirectoryInfoHandler(RequestHandler):
                 return Result(code=403, target=directory_id, username=handler.username)
 
             info_code = 0
-            ### generate access_rules text
+            # Generate access_rules text.
             access_rules = []
             if Permissions.VIEW_ACCESS_RULES in user.all_permissions:
                 for each_rule in directory.access_rules:
@@ -332,7 +332,7 @@ class RequestGetDirectoryInfoHandler(RequestHandler):
                         }
                     )
             else:
-                info_code = 1  # 无权访问目录
+                info_code = 1  # No permission to view directory access rules.
 
             data = {
                 "directory_id": directory.id,
@@ -1116,7 +1116,7 @@ class RequestRestoreDirectoryHandler(RequestHandler):
             op_id = folder.status_operation_id
 
             if op_id:
-                # 批量恢复文档
+                # Restore documents in bulk.
                 session.query(Document).execution_options(include_deleted=True).filter(
                     Document.status_operation_id == op_id,
                     Document.status == EntityStatus.DELETED,
@@ -1125,7 +1125,7 @@ class RequestRestoreDirectoryHandler(RequestHandler):
                     synchronize_session=False,
                 )
 
-                # 批量恢复文件夹
+                # Restore folders in bulk.
                 session.query(Folder).execution_options(include_deleted=True).filter(
                     Folder.status_operation_id == op_id,
                     Folder.status == EntityStatus.DELETED,

--- a/src/include/domains/documents/handlers/documents.py
+++ b/src/include/domains/documents/handlers/documents.py
@@ -156,7 +156,7 @@ class RequestGetDocumentInfoHandler(RequestHandler):
                 return Result(code=403, target=document_id, username=handler.username)
 
             info_code = 0
-            ### generate access_rules text
+            # Generate access_rules text.
             access_rules = []
             if Permissions.VIEW_ACCESS_RULES in user.all_permissions:
                 for each_rule in document.access_rules:
@@ -168,7 +168,7 @@ class RequestGetDocumentInfoHandler(RequestHandler):
                         }
                     )
             else:
-                info_code = 1  # 无权访问文档的权限
+                info_code = 1  # No permission to view document access rules.
 
             data = {
                 "document_id": document.id,
@@ -686,7 +686,7 @@ class RequestDownloadFileHandler(RequestHandler):
                 )
                 return
 
-        ### 服务器还需要发送一次响应
+        # The server still needs to send one more response.
         handler.send_file(task_id, offset)
 
 
@@ -727,7 +727,7 @@ class RequestUploadFileHandler(RequestHandler):
                 )
                 return
 
-        ### 服务器需要发送一次响应
+        # The server needs to send one response.
         handler.receive_file(task_id)
 
 

--- a/src/include/domains/documents/handlers/revisions.py
+++ b/src/include/domains/documents/handlers/revisions.py
@@ -151,7 +151,7 @@ class RequestDeleteRevisionHandler(RequestHandler):
     require_auth = True
 
     def handle(self, handler: ConnectionHandler):
-        ### be careful! this function will change the tree structure of revisions ###
+        # Be careful: this function changes the revision tree structure.
 
         revision_id = handler.data["id"]
 

--- a/src/include/domains/documents/queries/deletion_tree.py
+++ b/src/include/domains/documents/queries/deletion_tree.py
@@ -33,19 +33,19 @@ def fetch_subtree_for_deletion(
     dict[str, Folder],  # folder_map
 ]:
     """
-    一次性分析 root_folder_id 下整棵子树的可删性。
+    Analyze whether the subtree under root_folder_id can be deleted.
 
-    返回：
-        deletable_folder_ids  - 可以被删除的目录 ID 集合（自身有权删 且 无不可删后代）
-        deletable_doc_ids     - 可以被删除的文档 ID 集合
-        failed_items          - 鉴权失败的条目列表，用于返回给客户端
-        protected_folder_ids  - 因包含不可删后代而必须保留的目录 ID 集合
-        folder_map            - 目录 ID 到 Folder ORM 对象的映射
+    Returns:
+        deletable_folder_ids: Folder IDs that can be deleted, ordered deepest first.
+        deletable_doc_ids: Document IDs that can be deleted.
+        failed_items: Permission-failed items for client responses.
+        protected_folder_ids: Folder IDs kept because of undeletable descendants.
+        folder_map: Mapping from folder ID to Folder ORM object.
     """
     if now is None:
         now = time.time()
 
-    # ── Step 1: 用递归 CTE 捞出整棵子树的所有文件夹 ID ─────────────────────
+    # Step 1: Fetch all folder IDs in the subtree with a recursive CTE.
     exec_opts = {"include_deleted": True} if include_deleted else {}
     status_filter = "" if include_deleted else f"AND f.status = {EntityStatus.OK.value}"
 
@@ -64,18 +64,19 @@ def fetch_subtree_for_deletion(
         )
         SELECT id FROM subtree WHERE id != :root_id
         """)
-    # 注意：root_id 本身的可删性由调用方（handler）已检查，这里只分析"内容"
-    # 如果需要连 root 本身也纳入分析，去掉 WHERE id != :root_id 即可
+    # The caller has already checked whether root_id itself can be deleted.
+    # This function analyzes only its contents. Remove WHERE id != :root_id to
+    # include the root itself.
 
     all_subfolder_ids = [
         row[0]
         for row in session.execute(subtree_sql, {"root_id": root_folder_id}).fetchall()
     ]
 
-    # 将 root 本身也纳入需要加载的范围（用于后续 BFS 推导）
+    # Also load the root itself for the later BFS derivation.
     all_folder_ids_to_load = list(set(all_subfolder_ids + [root_folder_id]))
 
-    # ── Step 2: 批量加载所有文件夹（含 access_rules）────────────────────────
+    # Step 2: Load all folders in bulk, including access_rules.
     # Chunked to avoid SQLite bind-variable limit for large subtrees.
     folders: list[Folder] = []
     for chunk in batched(all_folder_ids_to_load, QUERY_CHUNK_SIZE):
@@ -89,7 +90,8 @@ def fetch_subtree_for_deletion(
     folder_map: dict[str, Folder] = {f.id: f for f in folders}
     actual_folder_ids = list(folder_map.keys())
 
-    # ── Step 3: 批量加载子树内所有文档（含 access_rules、revisions、files）──────────────────
+    # Step 3: Load all subtree documents, including access rules, revisions,
+    # and files.
     # Chunked to avoid SQLite bind-variable limit for large subtrees.
     documents: list[Document] = []
     for chunk in batched(actual_folder_ids, QUERY_CHUNK_SIZE):
@@ -104,7 +106,7 @@ def fetch_subtree_for_deletion(
             .all()
         )
 
-    # ── Step 4: 批量预取 OAE ────────────────────────────────────────────────
+    # Step 4: Prefetch OAE rows in bulk.
     # Chunked to avoid bind-variable limit for large subtrees.
     all_target_ids = actual_folder_ids + [doc.id for doc in documents]
     oae_entries: list[ObjectAccessEntry] = []
@@ -124,13 +126,13 @@ def fetch_subtree_for_deletion(
     for entry in oae_entries:
         oae_by_target[entry.target_identifier].append(entry)
 
-    # ── Step 5: 预取用户 block 状态（一次性，避免后续重复查询）──────────────
+    # Step 5: Prefetch user block state once to avoid repeated queries.
     is_globally_blocked, blocked_write_ids = prefetch_user_blocks(
         session, user, "write", now
     )
 
-    # ── Step 6: 对每个文档鉴权 ──────────────────────────────────────────────
-    # check_access_for_object 接收预加载好的 all_folders 和 oae_by_target，不产生额外 SQL
+    # Step 6: Check permissions for each document. check_access_for_object uses
+    # preloaded all_folders and oae_by_target, so it does not emit extra SQL.
     deletable_doc_ids: set[str] = set()
     failed_items: list[dict] = []
 
@@ -174,15 +176,15 @@ def fetch_subtree_for_deletion(
                     }
                 )
 
-    # ── Step 7: 对每个子文件夹自身鉴权 ─────────────────────────────────────
+    # Step 7: Check each child folder's own permissions.
     has_delete_directory_perm = "delete_directory" in user.all_permissions
 
-    # folder_self_deletable: 仅考虑自身权限，暂不考虑后代
+    # folder_self_deletable considers only the folder itself, not descendants.
     folder_self_deletable: dict[str, bool] = {}
 
     for folder in folders:
         if folder.id == root_folder_id:
-            # root 本身由 handler 层已鉴权，假设可删
+            # The handler already authorized the root itself, so assume deletable.
             folder_self_deletable[folder.id] = True
             continue
 
@@ -220,11 +222,10 @@ def fetch_subtree_for_deletion(
                     }
                 )
 
-    # ── Step 8: 自底向上推导"因包含不可删后代而必须保留的目录" ────────────
-    # 思路：维护一个 folder_has_undeletable_descendant: set[str]
-    # 对子树做拓扑排序（BFS 从叶到根），逐层向上冒泡
+    # Step 8: Derive folders that must be kept because they contain undeletable
+    # descendants. Build a leaf-to-root topological order and bubble state up.
 
-    # 构建父子关系映射
+    # Build parent-child relation maps.
     children_map: dict[str, list[str]] = defaultdict(list)
     parent_map: dict[str, Optional[str]] = {}
     for folder in folders:
@@ -232,12 +233,12 @@ def fetch_subtree_for_deletion(
         if folder.parent_id and folder.parent_id in set(actual_folder_ids):
             children_map[folder.parent_id].append(folder.id)
 
-    # 对每个文件夹：记录它"是否含有不可删内容"
-    # 初始化：自身权限不足 → 视为有不可删内容（对父节点而言）
+    # Record whether each folder contains undeletable content. A folder with
+    # insufficient self permissions is treated as undeletable for its parent.
     has_undeletable_content: dict[str, bool] = {}
 
-    # 按拓扑序从叶到根处理（BFS 反向）
-    # 先找出所有叶节点（在子树中没有子文件夹的节点）
+    # Process nodes in leaf-to-root topological order. Start with leaves, which
+    # have no child folders in the subtree.
 
     in_degree = {fid: len(children_map[fid]) for fid in actual_folder_ids}
     queue = deque([fid for fid in actual_folder_ids if in_degree[fid] == 0])
@@ -255,8 +256,8 @@ def fetch_subtree_for_deletion(
     if len(topo_order) != len(actual_folder_ids):
         raise RuntimeError("Cycle detected in folder hierarchy.")
 
-    # 按拓扑序（叶 → 根）计算 has_undeletable_content
-    # 文档归属到各自 folder 的"不可删内容"
+    # Calculate has_undeletable_content in leaf-to-root order. Documents count
+    # as undeletable content for their containing folder.
     folder_has_undeletable_doc: dict[str, bool] = defaultdict(bool)
     for doc in documents:
         is_active = (
@@ -277,18 +278,19 @@ def fetch_subtree_for_deletion(
             self_undeletable or child_undeletable or doc_undeletable
         )
 
-    # ── Step 9: 最终判定 (基于 topo_order 生成有序列表) ──────────────────────
+    # Step 9: Generate the final ordered result from topo_order.
     deletable_folder_ids: list[str] = []
     protected_folder_ids: set[str] = set()
 
-    # 遍历 topo_order。由于 topo_order 是从叶子到根的，
-    # 填充进 deletable_folder_ids 的顺序也将是“先删子目录，后删父目录”。
+    # Since topo_order runs from leaves to root, deletable_folder_ids will also
+    # delete child folders before parent folders.
     for fid in topo_order:
-        # 跳过 root_folder_id，它的处理由外部逻辑（Handler）决定
+        # Skip root_folder_id; external handler logic decides how to handle it.
         if fid == root_folder_id:
             continue
 
-        # 判断逻辑：自身有权删 且 没有任何不可删后代
+        # A folder is deletable only when it is deletable itself and has no
+        # undeletable descendants.
         can_delete_folder = folder_self_deletable.get(
             fid, False
         ) and not has_undeletable_content.get(fid, False)
@@ -299,7 +301,7 @@ def fetch_subtree_for_deletion(
             protected_folder_ids.add(fid)
 
     return (
-        deletable_folder_ids,  # 这是一个从深到浅的列表
+        deletable_folder_ids,  # Ordered from deepest to shallowest.
         deletable_doc_ids,
         failed_items,
         protected_folder_ids,

--- a/src/include/domains/identity/handlers/groups.py
+++ b/src/include/domains/identity/handlers/groups.py
@@ -25,7 +25,7 @@ class RequestListGroupsHandler(RequestHandler):
     def handle(self, handler: ConnectionHandler):
 
         with Session() as session:
-            user = User.get_existing(session, handler.username)  # 执行操作的用户
+            user = User.get_existing(session, handler.username)  # Requesting user.
 
             if Permissions.LIST_GROUPS not in user.all_permissions:
                 handler.conclude_request(
@@ -279,7 +279,7 @@ class RequestGetGroupInfoHandler(RequestHandler):
     def handle(self, handler: ConnectionHandler):
 
         with Session() as session:
-            user = User.get_existing(session, handler.username)  # 执行操作的用户
+            user = User.get_existing(session, handler.username)  # Requesting user.
 
             if not handler.data["group_name"]:
                 handler.conclude_request(
@@ -413,7 +413,8 @@ class RequestChangeGroupPermissionsHandler(RequestHandler):
                 )
                 return
 
-            if set(new_permissions) != group.all_permissions:  # 预判断，减少数据库开销
+            # Avoid unnecessary DB work.
+            if set(new_permissions) != group.all_permissions:
                 group.all_permissions = new_permissions
                 session.commit()
 

--- a/src/include/domains/identity/handlers/users.py
+++ b/src/include/domains/identity/handlers/users.py
@@ -420,7 +420,7 @@ class RequestBlockUserHandler(RequestHandler):
                     code=403, target=target_username, username=handler.username
                 )
 
-            # 创建主条目
+            # Create the parent entry.
             now = time.time()
             block_entry = UserBlockEntry(
                 username=target_username,
@@ -970,7 +970,8 @@ class RequestSetPasswdHandler(RequestHandler):
                 )
                 return
 
-            # 初始化操作员用户，如果没有指定 operator, 则以目标用户充任
+            # Initialize the operator user. If no operator is specified, the
+            # target user acts as the operator.
             if operator_username:
                 if not handler.token:
                     handler.conclude_request(
@@ -992,10 +993,10 @@ class RequestSetPasswdHandler(RequestHandler):
                         }
                     )
                     return
-            else:  # 这条路径下的 operator_user 应该永远也不会被调用。
+            else:  # operator_user should never be used on this path.
                 operator_user = None
 
-            if old_passwd:  # 如果指定了旧密码，说明是用户更改自己的密码
+            if old_passwd:  # An old password means the user changes their own password.
                 # Disallow these elevated flags when a user is changing their own password
                 _flags_set = []
                 if bypass_passwd_requirements:
@@ -1038,7 +1039,7 @@ class RequestSetPasswdHandler(RequestHandler):
                     )
                     return
 
-            else:  # 用户更改其他用户的密码
+            else:  # User changes another user's password.
                 if not operator_user:
                     handler.conclude_request(
                         **{

--- a/src/include/domains/identity/tokens.py
+++ b/src/include/domains/identity/tokens.py
@@ -19,7 +19,7 @@ class Token:
         self.username = username
         self.secret = secret
 
-        # 调用 raw.setter
+        # Invoke raw.setter.
         self.raw = raw_token
 
     @property
@@ -33,9 +33,9 @@ class Token:
             self.exp = None
             return
 
-        # 解析 token
+        # Decode the token.
         decoded = jwt.decode(self._raw, self.secret, algorithms="HS256")
-        if self.username:  # 一般不建议为 Token 预设用户名后再为 raw_token 赋值。
+        if self.username:  # Avoid presetting username before assigning raw_token.
             if decoded.get("username") != self.username:
                 raise ValueError("New token does not belong to the assigned user")
         else:

--- a/src/include/domains/operations/broadcast.py
+++ b/src/include/domains/operations/broadcast.py
@@ -13,7 +13,19 @@ def on_global_broadcast(msg: str):
             try:
                 stream = conn.create_stream()
                 if not stream.send_nowait(encoded_msg, frame_type=FrameType.CONCLUSION):
+                    outbound_queue = getattr(conn, "_outbound", None)
+                    outbound_queue_size = (
+                        outbound_queue.qsize()
+                        if outbound_queue is not None
+                        and hasattr(outbound_queue, "qsize")
+                        else None
+                    )
+                    remote_address = getattr(conn, "remote_address", None)
                     conn.close()
-                    logger.warning("Dropped slow client during global broadcast")
+                    logger.warning(
+                        "Dropped slow client during global broadcast: "
+                        f"remote_address={remote_address}, "
+                        f"outbound_queue_size={outbound_queue_size}"
+                    )
             except Exception as e:
                 logger.warning(f"Failed to forward global broadcast: {e}")

--- a/src/include/domains/operations/broadcast.py
+++ b/src/include/domains/operations/broadcast.py
@@ -12,6 +12,8 @@ def on_global_broadcast(msg: str):
         if conn._ws.protocol.state.name == "OPEN":
             try:
                 stream = conn.create_stream()
-                stream.send(encoded_msg, frame_type=FrameType.CONCLUSION)
+                if not stream.send_nowait(encoded_msg, frame_type=FrameType.CONCLUSION):
+                    conn.close()
+                    logger.warning("Dropped slow client during global broadcast")
             except Exception as e:
                 logger.warning(f"Failed to forward global broadcast: {e}")

--- a/src/include/domains/operations/commands/audit.py
+++ b/src/include/domains/operations/commands/audit.py
@@ -12,7 +12,7 @@ def log_audit(
     data: Optional[dict] = None,
     remote_address: Optional[str] = None,
 ) -> None:
-    """创建审计日志。"""
+    """Create an audit log entry."""
     if result == 400:
         return
 

--- a/src/include/transport/multiplexing.py
+++ b/src/include/transport/multiplexing.py
@@ -142,7 +142,9 @@ class MultiplexConnection:
                             )
                             self._ws.close(
                                 code=1002,
-                                reason="client-initiated streams must use odd ids",
+                                reason=(
+                                    "Protocol error: invalid client-initiated stream"
+                                ),
                             )
                             return
                         # Notify the local main thread about the peer stream.
@@ -269,15 +271,17 @@ class MultiplexConnection:
                     try:
                         self._ws.close()
                     except Exception:
+                        # The send failure is already reported to callers.
                         pass
                     return
 
                 if item.done is not None:
                     item.done.set()
         finally:
-            self._fail_pending_sends(
-                ConnectionError("MultiplexConnection send loop stopped")
+            error = self._send_error or ConnectionError(
+                "MultiplexConnection send loop stopped"
             )
+            self._fail_pending_sends(error)
 
     def _fail_pending_sends(self, exc: BaseException):
         while True:
@@ -299,8 +303,10 @@ class MultiplexConnection:
         try:
             self._outbound.put_nowait(None)
         except queue.Full:
+            # Pending senders were already failed; closing must not block.
             pass
         try:
             self._ws.close()
         except Exception:
+            # Close is best-effort because callers may invoke it repeatedly.
             pass

--- a/src/include/transport/multiplexing.py
+++ b/src/include/transport/multiplexing.py
@@ -52,7 +52,9 @@ class Stream:
         self, data: Data, frame_type: FrameType = FrameType.PROCESS
     ) -> bool:
         """Queue data for sending without waiting for socket I/O."""
-        return self.connection._send_frame_nowait(self.frame_id, frame_type, data)
+        return self.connection._send_frame(
+            self.frame_id, frame_type, data, wait_for_write=False
+        )
 
     def recv(self, timeout: Optional[float] = None) -> Frame:
         """接收属于这个流的数据，阻塞直到拿到为止"""
@@ -228,19 +230,19 @@ class MultiplexConnection:
 
         return True
 
-    def _send_frame(self, frame_id: int, frame_type: FrameType, data: Data):
-        self._enqueue_frame(frame_id, frame_type, data, wait_for_write=True)
-
-        if frame_type == FrameType.CONCLUSION:
-            with self._streams_lock:
-                self._streams.pop(frame_id, None)
-
-    def _send_frame_nowait(
-        self, frame_id: int, frame_type: FrameType, data: Data
+    def _send_frame(
+        self,
+        frame_id: int,
+        frame_type: FrameType,
+        data: Data,
+        *,
+        wait_for_write: bool = True,
     ) -> bool:
-        queued = self._enqueue_frame(frame_id, frame_type, data, wait_for_write=False)
+        queued = self._enqueue_frame(
+            frame_id, frame_type, data, wait_for_write=wait_for_write
+        )
 
-        if frame_type == FrameType.CONCLUSION:
+        if queued and frame_type == FrameType.CONCLUSION:
             with self._streams_lock:
                 self._streams.pop(frame_id, None)
 

--- a/src/include/transport/multiplexing.py
+++ b/src/include/transport/multiplexing.py
@@ -12,6 +12,7 @@ from websockets.typing import Data
 
 HEADER_FORMAT = "!IB"  # 4 bytes for frame_id, 1 byte for frame_type
 HEADER_SIZE = struct.calcsize(HEADER_FORMAT)
+OUTBOUND_QUEUE_SIZE = 1024
 
 logger = log.bind(name="multiplexer")
 
@@ -28,6 +29,13 @@ class Frame:
     data: bytes | memoryview  # can't be str
 
 
+@dataclass
+class _OutboundFrame:
+    payload: bytes
+    done: Optional[threading.Event] = None
+    exception: Optional[BaseException] = None
+
+
 class Stream:
     """代表一个独立的通信流（相当于一个虚拟的连接）"""
 
@@ -39,6 +47,12 @@ class Stream:
     def send(self, data: Data, frame_type: FrameType = FrameType.PROCESS):
         """在这个流上发送数据"""
         self.connection._send_frame(self.frame_id, frame_type, data)
+
+    def send_nowait(
+        self, data: Data, frame_type: FrameType = FrameType.PROCESS
+    ) -> bool:
+        """Queue data for sending without waiting for socket I/O."""
+        return self.connection._send_frame_nowait(self.frame_id, frame_type, data)
 
     def recv(self, timeout: Optional[float] = None) -> Frame:
         """接收属于这个流的数据，阻塞直到拿到为止"""
@@ -67,10 +81,16 @@ class MultiplexConnection:
         self._streams_lock = threading.Lock()
 
         self._new_streams: queue.Queue[Optional[Stream]] = queue.Queue()
+        self._outbound: queue.Queue[Optional[_OutboundFrame]] = queue.Queue(
+            OUTBOUND_QUEUE_SIZE
+        )
+        self._send_error: Optional[BaseException] = None
 
         self._is_running = True
         self._dispatcher = threading.Thread(target=self._recv_loop, daemon=True)
         self._dispatcher.start()
+        self._writer = threading.Thread(target=self._send_loop, daemon=True)
+        self._writer.start()
 
     def create_stream(self) -> Stream:
         """主动发起一个新的数据流"""
@@ -150,8 +170,7 @@ class MultiplexConnection:
                 for stream in self._streams.values():
                     stream._put_incoming_frame(None)
 
-    def _send_frame(self, frame_id: int, frame_type: FrameType, data: Data):
-
+    def _encode_frame(self, frame_id: int, frame_type: FrameType, data: Data) -> bytes:
         if isinstance(data, str):
             data = data.encode("utf-8")
 
@@ -162,14 +181,123 @@ class MultiplexConnection:
 
         payload[HEADER_SIZE:] = data
 
-        self._ws.send(payload)
+        return bytes(payload)
+
+    def _enqueue_frame(
+        self,
+        frame_id: int,
+        frame_type: FrameType,
+        data: Data,
+        *,
+        wait_for_write: bool = True,
+        timeout: Optional[float] = None,
+    ) -> bool:
+        if not self._is_running:
+            if wait_for_write:
+                raise ConnectionError("MultiplexConnection has been closed")
+            return False
+
+        if self._send_error is not None:
+            if wait_for_write:
+                raise ConnectionError("MultiplexConnection send loop failed") from (
+                    self._send_error
+                )
+            return False
+
+        item = _OutboundFrame(
+            payload=self._encode_frame(frame_id, frame_type, data),
+            done=threading.Event() if wait_for_write else None,
+        )
+
+        try:
+            if wait_for_write:
+                self._outbound.put(item, timeout=timeout)
+            else:
+                self._outbound.put_nowait(item)
+        except queue.Full:
+            if wait_for_write:
+                raise TimeoutError("Timed out while queueing WebSocket frame")
+            return False
+
+        if item.done is None:
+            return True
+
+        item.done.wait()
+        if item.exception is not None:
+            raise ConnectionError("Failed to send WebSocket frame") from item.exception
+
+        return True
+
+    def _send_frame(self, frame_id: int, frame_type: FrameType, data: Data):
+        self._enqueue_frame(frame_id, frame_type, data, wait_for_write=True)
 
         if frame_type == FrameType.CONCLUSION:
             with self._streams_lock:
                 self._streams.pop(frame_id, None)
 
+    def _send_frame_nowait(
+        self, frame_id: int, frame_type: FrameType, data: Data
+    ) -> bool:
+        queued = self._enqueue_frame(frame_id, frame_type, data, wait_for_write=False)
+
+        if frame_type == FrameType.CONCLUSION:
+            with self._streams_lock:
+                self._streams.pop(frame_id, None)
+
+        return queued
+
+    def _send_loop(self):
+        try:
+            while True:
+                item = self._outbound.get()
+                if item is None:
+                    return
+
+                try:
+                    if not self._is_running:
+                        raise ConnectionError("MultiplexConnection has been closed")
+                    self._ws.send(item.payload)
+                except Exception as exc:
+                    self._send_error = exc
+                    self._is_running = False
+                    item.exception = exc
+                    if item.done is not None:
+                        item.done.set()
+                    self._fail_pending_sends(exc)
+                    try:
+                        self._ws.close()
+                    except Exception:
+                        pass
+                    return
+
+                if item.done is not None:
+                    item.done.set()
+        finally:
+            self._fail_pending_sends(
+                ConnectionError("MultiplexConnection send loop stopped")
+            )
+
+    def _fail_pending_sends(self, exc: BaseException):
+        while True:
+            try:
+                item = self._outbound.get_nowait()
+            except queue.Empty:
+                return
+
+            if item is None:
+                continue
+
+            item.exception = exc
+            if item.done is not None:
+                item.done.set()
+
     def close(self):
         self._is_running = False
+        self._fail_pending_sends(ConnectionError("MultiplexConnection has been closed"))
+        try:
+            self._outbound.put_nowait(None)
+        except queue.Full:
+            pass
         try:
             self._ws.close()
         except Exception:

--- a/src/include/transport/multiplexing.py
+++ b/src/include/transport/multiplexing.py
@@ -113,6 +113,16 @@ class MultiplexConnection:
 
                 with self._streams_lock:
                     if frame.frame_id not in self._streams:
+                        if frame.frame_id % 2 == 0:
+                            logger.warning(
+                                f"({self.remote_address[0]}): Client attempted to "
+                                f"open server-reserved stream id {frame.frame_id}"
+                            )
+                            self._ws.close(
+                                code=1002,
+                                reason="client-initiated streams must use odd ids",
+                            )
+                            return
                         # 对方发起的新流，通知本地主线程
                         new_stream = Stream(self, frame.frame_id)
                         self._streams[frame.frame_id] = new_stream

--- a/src/include/transport/multiplexing.py
+++ b/src/include/transport/multiplexing.py
@@ -37,7 +37,7 @@ class _OutboundFrame:
 
 
 class Stream:
-    """代表一个独立的通信流（相当于一个虚拟的连接）"""
+    """Represent an independent communication stream, like a virtual connection."""
 
     def __init__(self, connection: "MultiplexConnection", frame_id: int):
         self.connection = connection
@@ -45,7 +45,7 @@ class Stream:
         self._queue: queue.Queue = queue.Queue(100)
 
     def send(self, data: Data, frame_type: FrameType = FrameType.PROCESS):
-        """在这个流上发送数据"""
+        """Send data on this stream."""
         self.connection._send_frame(self.frame_id, frame_type, data)
 
     def send_nowait(
@@ -57,14 +57,14 @@ class Stream:
         )
 
     def recv(self, timeout: Optional[float] = None) -> Frame:
-        """接收属于这个流的数据，阻塞直到拿到为止"""
+        """Receive data for this stream, blocking until a frame is available."""
         frame = self._queue.get(timeout=timeout)
         if frame is None:
             raise ConnectionError("MultiplexConnection has been closed")
         return frame
 
     def _put_incoming_frame(self, frame: Optional[Frame]):
-        """由 Dispatcher 调用，将属于该流的数据塞入队列"""
+        """Queue a frame for this stream. Called by the dispatcher."""
         self._queue.put(frame)
 
 
@@ -95,10 +95,10 @@ class MultiplexConnection:
         self._writer.start()
 
     def create_stream(self) -> Stream:
-        """主动发起一个新的数据流"""
+        """Initiate a new data stream."""
         with self._id_lock:
             frame_id = self._next_frame_id
-            self._next_frame_id += 2  # 保持奇偶性
+            self._next_frame_id += 2  # Preserve parity.
 
         new_stream = Stream(self, frame_id)
         with self._streams_lock:
@@ -107,7 +107,7 @@ class MultiplexConnection:
         return new_stream
 
     def accept_stream(self) -> Optional[Stream]:
-        """阻塞等待并获取对方创建的新的工作流"""
+        """Wait for and return a new stream created by the peer."""
         return self._new_streams.get()
 
     def _recv_loop(self):
@@ -145,7 +145,7 @@ class MultiplexConnection:
                                 reason="client-initiated streams must use odd ids",
                             )
                             return
-                        # 对方发起的新流，通知本地主线程
+                        # Notify the local main thread about the peer stream.
                         new_stream = Stream(self, frame.frame_id)
                         self._streams[frame.frame_id] = new_stream
                         self._new_streams.put(new_stream)
@@ -154,7 +154,7 @@ class MultiplexConnection:
 
                 target_stream._put_incoming_frame(frame)
 
-                # 如果对方发来了结束帧，回收路由表内存
+                # Reclaim routing table memory when the peer sends an end frame.
                 if frame.frame_type == FrameType.CONCLUSION:
                     with self._streams_lock:
                         self._streams.pop(frame.frame_id, None)
@@ -165,9 +165,9 @@ class MultiplexConnection:
             logger.exception(f"({self.remote_address[0]}): Error in receive loop")
         finally:
             self._is_running = False
-            self._new_streams.put(None)  # 唤醒在 accept_stream 阻塞的线程
+            self._new_streams.put(None)  # Wake threads blocked in accept_stream.
 
-            # 唤醒所有正在 Stream.recv() 阻塞的线程，防止死锁
+            # Wake all threads blocked in Stream.recv() to prevent deadlocks.
             with self._streams_lock:
                 for stream in self._streams.values():
                     stream._put_incoming_frame(None)

--- a/src/include/transport/request_handler.py
+++ b/src/include/transport/request_handler.py
@@ -25,9 +25,10 @@ class RequestHandler(ABC):
             Abstract method to process a request. Must be implemented by subclasses.
             Returns:
                 1. -> None
-                    该结果将被忽略，用于不适合通过返回值提交审计信息的逻辑。
+                    The result is ignored. Use this for flows that should not
+                    submit audit information through the return value.
                 2. -> Result
-                    该结果将作为审计信息提交。
+                    The result is submitted as audit information.
     """
 
     # This property defines the json structure of the request data.

--- a/src/include/transport/router.py
+++ b/src/include/transport/router.py
@@ -113,16 +113,16 @@ from include.transport.request_handler import RequestHandler, Result
 logger = log.bind(name="connection_handler")
 
 available_functions: dict[str, type[RequestHandler]] = {
-    # 认证类
+    # Authentication
     "login": RequestLoginHandler,
     "refresh_token": RequestRefreshTokenHandler,
-    # 两步验证类
+    # Two-factor authentication
     "setup_2fa": RequestSetup2FAHandler,
     "cancel_2fa_setup": RequestCancel2FASetupHandler,  # especially for cancelling setup
     "validate_2fa": RequestValidate2FAHandler,
     "disable_2fa": RequestDisable2FAHandler,
     "get_2fa_status": RequestGet2FAStatusHandler,
-    # 文档类
+    # Documents
     "get_document": RequestGetDocumentHandler,
     "create_document": RequestCreateDocumentHandler,
     "upload_document": RequestUploadDocumentHandler,
@@ -135,15 +135,15 @@ available_functions: dict[str, type[RequestHandler]] = {
     "get_document_access_rules": RequestGetDocumentAccessRulesHandler,
     "set_document_rules": RequestSetDocumentRulesHandler,
     "set_document_tags": RequestSetDocumentTagsHandler,
-    # 修订版本类
+    # Revisions
     "list_revisions": RequestListRevisionsHandler,
     "get_revision": RequestGetRevisionHandler,
     "set_current_revision": RequestSetDocumentRevisionHandler,
     "delete_revision": RequestDeleteRevisionHandler,
-    # 文件类
+    # Files
     "download_file": RequestDownloadFileHandler,
     "upload_file": RequestUploadFileHandler,
-    # 目录类
+    # Directories
     "list_directory": RequestListDirectoryHandler,
     "get_directory_info": RequestGetDirectoryInfoHandler,
     "get_directory_access_rules": RequestGetDirectoryAccessRulesHandler,
@@ -172,18 +172,18 @@ available_functions: dict[str, type[RequestHandler]] = {
     "change_user_groups": RequestChangeUserGroupsHandler,
     "change_user_permissions": RequestChangeUserPermissionsHandler,
     "set_passwd": RequestSetPasswdHandler,
-    # 用户组类
+    # Groups
     "list_groups": RequestListGroupsHandler,
     "create_group": RequestCreateGroupHandler,
     "delete_group": RequestDeleteGroupHandler,
     "rename_group": RequestRenameGroupHandler,
     "get_group_info": RequestGetGroupInfoHandler,
     "change_group_permissions": RequestChangeGroupPermissionsHandler,
-    # 访问类
+    # Access
     "grant_access": RequestGrantAccessHandler,
     "revoke_access": RequestRevokeAccessHandler,
     "view_access_entries": RequestViewAccessEntriesHandler,
-    # 系统类
+    # System
     "lockdown": RequestLockdownHandler,
     "view_audit_logs": RequestViewAuditLogsHandler,
     # Keyring
@@ -194,7 +194,7 @@ available_functions: dict[str, type[RequestHandler]] = {
     "list_user_keys": RequestListUserKeysHandler,
 }
 
-# 定义白名单内的请求。这些请求即使在防范禁闭时也对所有用户可用。
+# Requests that remain available to all users during lockdown.
 whitelisted_functions = [
     "server_info",
     "login",
@@ -311,8 +311,8 @@ def handle_request(stream: Stream):
             "timestamp": time.time(),
         }
         stream.send(orjson.dumps(response), frame_type=FrameType.CONCLUSION)
-        # 强制断开 WebSocket 连接
-        # 1008 是 WebSocket 协议定义的 Policy Violation 错误码
+        # Force-close the WebSocket connection.
+        # 1008 is the WebSocket policy violation close code.
         stream.connection.close()
         stream.connection._ws.close(code=1008, reason="IP temporarily blocked")
         return
@@ -426,7 +426,7 @@ def handle_request(stream: Stream):
             return
 
         if callback is None:
-            # 为不适合采用 return 提交审计信息的逻辑预留。
+            # Reserved for flows that should not submit audit data via return.
             return
 
         _log_handler_result(action, callback, this_handler.remote_address)

--- a/src/main.py
+++ b/src/main.py
@@ -240,7 +240,7 @@ def server_init():
         ],
     )
 
-    # 将密码输出到根目录下的 admin_password.txt 文件
+    # Write the generated password to admin_password.txt in the project root.
     with open(ROOT_ABSPATH / "admin_password.txt", "w", encoding="utf-8") as pwd_file:
         pwd_file.write(f"{password}\n")
 
@@ -257,12 +257,12 @@ def server_init():
     cert_path = global_config["server"]["ssl_certfile"]
     key_path = global_config["server"]["ssl_keyfile"]
 
-    # 使用python包 cryptography 生成自签名证书和私钥
+    # Generate a self-signed certificate and private key with cryptography.
     if not (os.path.exists(cert_path) and os.path.exists(key_path)):
-        # 生成 ECC 私钥
+        # Generate the ECC private key.
         private_key = ec.generate_private_key(ec.SECP256R1(), default_backend())
 
-        # 生成自签名证书
+        # Generate the self-signed certificate.
         subject = issuer = x509.Name(
             [
                 x509.NameAttribute(
@@ -290,7 +290,7 @@ def server_init():
             .sign(private_key, hashes.SHA256(), default_backend())
         )
 
-        # 写入私钥
+        # Write the private key.
         with open(key_path, "wb") as f:
             f.write(
                 private_key.private_bytes(
@@ -300,7 +300,7 @@ def server_init():
                 )
             )
 
-        # 写入证书
+        # Write the certificate.
         with open(cert_path, "wb") as f:
             f.write(cert.public_bytes(serialization.Encoding.PEM))
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -201,7 +201,7 @@ class AsyncMultiplexConnection:
         except Exception:
             pass
 
-        # 显式取消并回收 _dispatcher_task
+        # Explicitly cancel and await _dispatcher_task.
         if hasattr(self, "_dispatcher_task") and not self._dispatcher_task.done():
             self._dispatcher_task.cancel()
             try:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -90,7 +90,7 @@ class AsyncStream:
 class AsyncMultiplexConnection:
     def __init__(self, websocket: ClientConnection):
         self._ws = websocket
-        self._next_frame_id = 2
+        self._next_frame_id = 1
         self._id_lock = threading.Lock()
         self._streams: Dict[int, AsyncStream] = {}
         self._streams_lock = threading.Lock()
@@ -109,10 +109,19 @@ class AsyncMultiplexConnection:
 
         return new_stream
 
-    async def accept_stream(self) -> Optional[AsyncStream]:
-        return await asyncio.get_running_loop().run_in_executor(
-            None, self._new_streams.get
-        )
+    async def accept_stream(
+        self, timeout: Optional[float] = None
+    ) -> Optional[AsyncStream]:
+        try:
+            if timeout is None:
+                return await asyncio.get_running_loop().run_in_executor(
+                    None, self._new_streams.get
+                )
+            return await asyncio.get_running_loop().run_in_executor(
+                None, lambda: self._new_streams.get(timeout=timeout)
+            )
+        except queue.Empty:
+            raise TimeoutError("Server stream accept timeout")
 
     async def _recv_loop(self):
         try:
@@ -138,6 +147,10 @@ class AsyncMultiplexConnection:
 
                 with self._streams_lock:
                     if frame.frame_id not in self._streams:
+                        if frame.frame_id % 2 != 0:
+                            self._is_running = False
+                            await self._ws.close()
+                            return
                         new_stream = AsyncStream(self, frame.frame_id)
                         self._streams[frame.frame_id] = new_stream
                         self._new_streams.put(new_stream)
@@ -402,6 +415,20 @@ class CFMSTestClient:
                 raise RuntimeError(f"Invalid response from server: {e}") from e
 
         raise RuntimeError("Unexpected response format from server")
+
+    async def accept_event(self, timeout: Optional[float] = None) -> Dict[str, Any]:
+        if self.multiplexer is None:
+            raise RuntimeError("Not connected to server. Call connect() first.")
+
+        stream = await self.multiplexer.accept_stream(timeout=timeout)
+        if stream is None:
+            raise ConnectionError("Connection closed before receiving server event")
+
+        frame = await stream.recv(timeout=timeout)
+        payload = await self._parse_frame_data(frame)
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"Unexpected event payload: {payload}")
+        return payload
 
     async def send_raw_request(
         self,

--- a/tests/test_multiplexing.py
+++ b/tests/test_multiplexing.py
@@ -1,7 +1,16 @@
 import asyncio
+import threading
+import time
 
 import pytest
 
+from include.domains.operations.broadcast import on_global_broadcast
+from include.shared import clients, clients_lock
+from include.transport.multiplexing import (
+    OUTBOUND_QUEUE_SIZE,
+    FrameType,
+    MultiplexConnection,
+)
 from tests.test_client import AsyncMultiplexConnection
 
 
@@ -36,3 +45,168 @@ async def test_test_client_uses_odd_client_stream_ids():
         assert third.frame_id == 5
     finally:
         await connection.close()
+
+
+class _OpenState:
+    name = "OPEN"
+
+
+class _Protocol:
+    state = _OpenState()
+
+
+class _SyncWebSocket:
+    def __init__(
+        self, *, block_send: bool = False, send_error: Exception | None = None
+    ):
+        self.remote_address = ("127.0.0.1", 12345)
+        self.protocol = _Protocol()
+        self.sent = []
+        self.closed = threading.Event()
+        self.send_entered = threading.Event()
+        self.release_send = threading.Event()
+        self.block_send = block_send
+        self.send_error = send_error
+
+    def recv(self):
+        self.closed.wait()
+        raise RuntimeError("closed")
+
+    def send(self, payload):
+        self.send_entered.set()
+        if self.block_send:
+            self.release_send.wait()
+        if self.send_error is not None:
+            raise self.send_error
+        self.sent.append(payload)
+
+    def close(self, *args, **kwargs):
+        self.release_send.set()
+        self.closed.set()
+
+
+def test_stream_send_waits_until_writer_sends():
+    websocket = _SyncWebSocket(block_send=True)
+    connection = MultiplexConnection(websocket)
+    stream = connection.create_stream()
+    done = threading.Event()
+
+    sender = threading.Thread(
+        target=lambda: (stream.send(b"payload", FrameType.PROCESS), done.set())
+    )
+    sender.start()
+
+    try:
+        assert websocket.send_entered.wait(timeout=1)
+        assert not done.wait(timeout=0.05)
+
+        websocket.release_send.set()
+        assert done.wait(timeout=1)
+        sender.join(timeout=1)
+        assert len(websocket.sent) == 1
+    finally:
+        connection.close()
+
+
+def test_stream_send_nowait_does_not_wait_for_socket_io():
+    websocket = _SyncWebSocket(block_send=True)
+    connection = MultiplexConnection(websocket)
+    stream = connection.create_stream()
+
+    try:
+        assert stream.send_nowait(b"payload", FrameType.PROCESS) is True
+        assert websocket.send_entered.wait(timeout=1)
+        assert websocket.sent == []
+
+        websocket.release_send.set()
+        deadline = time.monotonic() + 1
+        while not websocket.sent and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert len(websocket.sent) == 1
+    finally:
+        connection.close()
+
+
+def test_stream_send_nowait_returns_false_when_queue_is_full():
+    websocket = _SyncWebSocket(block_send=True)
+    connection = MultiplexConnection(websocket)
+
+    try:
+        assert connection.create_stream().send_nowait(b"blocked") is True
+        assert websocket.send_entered.wait(timeout=1)
+
+        for _ in range(OUTBOUND_QUEUE_SIZE):
+            assert connection.create_stream().send_nowait(b"queued") is True
+
+        assert connection.create_stream().send_nowait(b"overflow") is False
+    finally:
+        connection.close()
+
+
+def test_stream_send_raises_when_writer_fails():
+    websocket = _SyncWebSocket(send_error=OSError("boom"))
+    connection = MultiplexConnection(websocket)
+    stream = connection.create_stream()
+
+    try:
+        with pytest.raises(ConnectionError):
+            stream.send(b"payload", FrameType.PROCESS)
+    finally:
+        connection.close()
+
+
+def test_concurrent_stream_sends_are_serialized_by_writer():
+    websocket = _SyncWebSocket()
+    connection = MultiplexConnection(websocket)
+    barrier = threading.Barrier(6)
+    errors = []
+
+    def send_from_thread(index: int):
+        try:
+            stream = connection.create_stream()
+            barrier.wait(timeout=1)
+            stream.send(f"payload-{index}".encode(), FrameType.PROCESS)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=send_from_thread, args=(index,)) for index in range(5)
+    ]
+
+    try:
+        for thread in threads:
+            thread.start()
+
+        barrier.wait(timeout=1)
+
+        for thread in threads:
+            thread.join(timeout=1)
+
+        assert errors == []
+        assert len(websocket.sent) == 5
+    finally:
+        connection.close()
+
+
+def test_broadcast_does_not_wait_for_slow_client():
+    websocket = _SyncWebSocket(block_send=True)
+    connection = MultiplexConnection(websocket)
+    done = threading.Event()
+
+    with clients_lock:
+        clients.add(connection)
+
+    broadcaster = threading.Thread(
+        target=lambda: (on_global_broadcast("hello"), done.set())
+    )
+    broadcaster.start()
+
+    try:
+        assert done.wait(timeout=1)
+        assert websocket.send_entered.wait(timeout=1)
+        assert websocket.sent == []
+    finally:
+        with clients_lock:
+            clients.discard(connection)
+        connection.close()
+        broadcaster.join(timeout=1)

--- a/tests/test_multiplexing.py
+++ b/tests/test_multiplexing.py
@@ -1,0 +1,38 @@
+import asyncio
+
+import pytest
+
+from tests.test_client import AsyncMultiplexConnection
+
+
+class _IdleWebSocket:
+    def __init__(self):
+        self.sent = []
+        self._closed = asyncio.Event()
+
+    async def recv(self):
+        await self._closed.wait()
+        return b""
+
+    async def send(self, payload):
+        self.sent.append(payload)
+
+    async def close(self):
+        self._closed.set()
+
+
+@pytest.mark.asyncio
+async def test_test_client_uses_odd_client_stream_ids():
+    websocket = _IdleWebSocket()
+    connection = AsyncMultiplexConnection(websocket)
+
+    try:
+        first = connection.create_stream()
+        second = connection.create_stream()
+        third = connection.create_stream()
+
+        assert first.frame_id == 1
+        assert second.frame_id == 3
+        assert third.frame_id == 5
+    finally:
+        await connection.close()

--- a/tests/test_multiplexing.py
+++ b/tests/test_multiplexing.py
@@ -143,6 +143,37 @@ def test_stream_send_nowait_returns_false_when_queue_is_full():
         connection.close()
 
 
+def test_stream_send_nowait_conclusion_removes_stream_when_queued():
+    websocket = _SyncWebSocket(block_send=True)
+    connection = MultiplexConnection(websocket)
+    stream = connection.create_stream()
+
+    try:
+        assert stream.frame_id in connection._streams
+        assert stream.send_nowait(b"done", FrameType.CONCLUSION) is True
+        assert stream.frame_id not in connection._streams
+    finally:
+        connection.close()
+
+
+def test_stream_send_nowait_conclusion_keeps_stream_when_queue_is_full():
+    websocket = _SyncWebSocket(block_send=True)
+    connection = MultiplexConnection(websocket)
+
+    try:
+        assert connection.create_stream().send_nowait(b"blocked") is True
+        assert websocket.send_entered.wait(timeout=1)
+
+        for _ in range(OUTBOUND_QUEUE_SIZE):
+            assert connection.create_stream().send_nowait(b"queued") is True
+
+        stream = connection.create_stream()
+        assert stream.send_nowait(b"overflow", FrameType.CONCLUSION) is False
+        assert stream.frame_id in connection._streams
+    finally:
+        connection.close()
+
+
 def test_stream_send_raises_when_writer_fails():
     websocket = _SyncWebSocket(send_error=OSError("boom"))
     connection = MultiplexConnection(websocket)

--- a/tests/test_multiplexing.py
+++ b/tests/test_multiplexing.py
@@ -4,6 +4,7 @@ import time
 
 import pytest
 
+from include.domains.operations import broadcast as broadcast_module
 from include.domains.operations.broadcast import on_global_broadcast
 from include.shared import clients, clients_lock
 from include.transport.multiplexing import (
@@ -186,6 +187,52 @@ def test_stream_send_raises_when_writer_fails():
         connection.close()
 
 
+def test_pending_stream_sends_preserve_writer_failure_cause():
+    send_error = OSError("boom")
+    websocket = _SyncWebSocket(block_send=True, send_error=send_error)
+    connection = MultiplexConnection(websocket)
+    errors = []
+
+    def send_and_capture(index: int):
+        try:
+            stream = connection.create_stream()
+            stream.send(f"payload-{index}".encode(), FrameType.PROCESS)
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [
+        threading.Thread(target=send_and_capture, args=(index,)) for index in range(4)
+    ]
+
+    try:
+        threads[0].start()
+        assert websocket.send_entered.wait(timeout=1)
+
+        for thread in threads[1:]:
+            thread.start()
+
+        deadline = time.monotonic() + 1
+        while connection._outbound.qsize() < len(threads) - 1:
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(0.01)
+
+        assert connection._outbound.qsize() == len(threads) - 1
+        websocket.release_send.set()
+
+        for thread in threads:
+            thread.join(timeout=1)
+
+        assert len(errors) == len(threads)
+        assert all(isinstance(exc, ConnectionError) for exc in errors)
+        assert all(exc.__cause__ is send_error for exc in errors)
+    finally:
+        websocket.release_send.set()
+        connection.close()
+        for thread in threads:
+            thread.join(timeout=1)
+
+
 def test_concurrent_stream_sends_are_serialized_by_writer():
     websocket = _SyncWebSocket()
     connection = MultiplexConnection(websocket)
@@ -241,3 +288,37 @@ def test_broadcast_does_not_wait_for_slow_client():
             clients.discard(connection)
         connection.close()
         broadcaster.join(timeout=1)
+
+
+def test_broadcast_logs_diagnostics_when_dropping_slow_client(monkeypatch):
+    websocket = _SyncWebSocket(block_send=True)
+    connection = MultiplexConnection(websocket)
+    warnings = []
+
+    class _Logger:
+        def warning(self, message):
+            warnings.append(message)
+
+    monkeypatch.setattr(broadcast_module, "logger", _Logger())
+
+    try:
+        assert connection.create_stream().send_nowait(b"blocked") is True
+        assert websocket.send_entered.wait(timeout=1)
+
+        for _ in range(OUTBOUND_QUEUE_SIZE):
+            assert connection.create_stream().send_nowait(b"queued") is True
+
+        with clients_lock:
+            clients.add(connection)
+
+        on_global_broadcast("hello")
+
+        assert warnings == [
+            "Dropped slow client during global broadcast: "
+            "remote_address=('127.0.0.1', 12345), "
+            f"outbound_queue_size={OUTBOUND_QUEUE_SIZE}"
+        ]
+    finally:
+        with clients_lock:
+            clients.discard(connection)
+        connection.close()

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,9 +1,21 @@
+import asyncio
+import ssl
+import struct
 import time
 
 import pytest
+from websockets.asyncio.client import connect
+from websockets.exceptions import ConnectionClosed
 
+from tests.support.test_config import ServerTestSettings
 from tests.test_client import CFMSTestClient
 from tests.utils import assert_error, assert_success
+
+
+def _format_ws_host(host: str) -> str:
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
 
 
 class TestSystemManagement:
@@ -36,6 +48,55 @@ class TestSystemManagement:
             # Revert lockdown
             unlockdown_resp = await authenticated_client.set_lockdown(False)
             assert_success(unlockdown_resp)
+
+    @pytest.mark.asyncio
+    async def test_lockdown_broadcast_event(
+        self,
+        authenticated_client: CFMSTestClient,
+        test_server_settings: ServerTestSettings,
+    ):
+        event_client = CFMSTestClient(
+            host=test_server_settings.host,
+            port=test_server_settings.port,
+            use_ssl=test_server_settings.use_ssl,
+        )
+        await event_client.connect()
+
+        try:
+            lockdown_resp = await authenticated_client.set_lockdown(True)
+            assert_success(lockdown_resp)
+
+            event = await event_client.accept_event(timeout=5)
+            assert event == {"event": "lockdown", "data": {"status": True}}
+        finally:
+            unlockdown_resp = await authenticated_client.set_lockdown(False)
+            assert_success(unlockdown_resp)
+            await event_client.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_even_client_initiated_stream_is_rejected(
+        self,
+        server_process,
+        test_server_settings: ServerTestSettings,
+    ):
+        ssl_context = ssl.create_default_context()
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+        uri = (
+            f"wss://{_format_ws_host(test_server_settings.host)}:"
+            f"{test_server_settings.port}"
+        )
+
+        async with connect(uri, ssl=ssl_context, proxy=None) as websocket:
+            request = b'{"action":"server_info","data":{}}'
+            payload = bytearray(5 + len(request))
+            struct.pack_into("!IB", payload, 0, 2, 0)
+            payload[5:] = request
+
+            await websocket.send(payload)
+
+            with pytest.raises(ConnectionClosed):
+                await asyncio.wait_for(websocket.recv(), timeout=5)
 
     @pytest.mark.asyncio
     async def test_audit_logs(self, authenticated_client: CFMSTestClient):

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -95,8 +95,14 @@ class TestSystemManagement:
 
             await websocket.send(payload)
 
-            with pytest.raises(ConnectionClosed):
+            with pytest.raises(ConnectionClosed) as excinfo:
                 await asyncio.wait_for(websocket.recv(), timeout=5)
+
+            assert excinfo.value.code == 1002
+            assert (
+                excinfo.value.reason
+                == "Protocol error: invalid client-initiated stream"
+            )
 
     @pytest.mark.asyncio
     async def test_audit_logs(self, authenticated_client: CFMSTestClient):


### PR DESCRIPTION
Fix #67

## Summary by Sourcery

Implement asynchronous, capacity-limited outbound multiplexing with parity enforcement for client/server streams and tighten connection handling, while improving documentation and permission comments across identity, access, and document domains.

New Features:
- Add non-blocking stream send API and background writer thread for multiplexed connections with bounded outbound queue.
- Introduce client event subscription helper to receive server broadcast events over multiplexed streams.
- Enforce odd/even stream ID parity for client- and server-initiated multiplexed streams to prevent misuse.

Bug Fixes:
- Reject client-initiated multiplexed streams that use server-reserved even IDs and close the connection with a protocol error.
- Ensure deletion-tree analysis and bulk purge logic behave correctly with documented ordering and permission handling semantics.

Enhancements:
- Refine connection shutdown behavior to fail pending sends, propagate writer errors, and avoid deadlocks on close.
- Improve docstrings and inline comments across authorization, identity, documents, permissions, routing, TLS setup, and audit logging for clearer behavior and intent.
- Clarify access rule visibility responses and group/permission change handling for directory and document handlers.
- Document JWT token lifecycle, per-user secret keys, group memberships, and permission validity windows in the identity model.

Tests:
- Add comprehensive multiplexing tests covering client stream ID parity, outbound queue behavior, writer failure handling, concurrency, and broadcast performance.
- Extend system tests to cover lockdown broadcast events and enforcement of even/odd stream ID rules on raw WebSocket connections.
- Adjust client multiplexing tests to use odd stream IDs and support timeouts when accepting server-initiated streams.