### PR TITLE
Refactor connection modules and streamline exception handling

### DIFF
--- a/src/include/domains/operations/broadcast.py
+++ b/src/include/domains/operations/broadcast.py
@@ -13,7 +13,7 @@ def on_global_broadcast(msg: str):
             try:
                 stream = conn.open_stream()
                 if not stream.send_nowait(encoded_msg, frame_type=FrameType.CONCLUSION):
-                    outbound_queue = getattr(conn, "_outbound", None)
+                    outbound_queue = getattr(conn, "_pending_outbound_frames", None)
                     outbound_queue_size = (
                         outbound_queue.qsize()
                         if outbound_queue is not None

--- a/src/include/domains/operations/broadcast.py
+++ b/src/include/domains/operations/broadcast.py
@@ -1,7 +1,7 @@
 from loguru import logger
 
 from include.shared import clients, clients_lock
-from include.transport.multiplexing import FrameType
+from include.transport.multiplexing import ConnectionClosedError, FrameType
 
 
 def on_global_broadcast(msg: str):
@@ -9,23 +9,20 @@ def on_global_broadcast(msg: str):
     with clients_lock:
         clients_copy = list(clients)
     for conn in clients_copy:
-        if conn._ws.protocol.state.name == "OPEN":
-            try:
-                stream = conn.open_stream()
-                if not stream.send_nowait(encoded_msg, frame_type=FrameType.CONCLUSION):
-                    outbound_queue = getattr(conn, "_pending_outbound_frames", None)
-                    outbound_queue_size = (
-                        outbound_queue.qsize()
-                        if outbound_queue is not None
-                        and hasattr(outbound_queue, "qsize")
-                        else None
-                    )
-                    remote_address = getattr(conn, "remote_address", None)
-                    conn.close()
-                    logger.warning(
-                        "Dropped slow client during global broadcast: "
-                        f"remote_address={remote_address}, "
-                        f"outbound_queue_size={outbound_queue_size}"
-                    )
-            except Exception as e:
-                logger.warning(f"Failed to forward global broadcast: {e}")
+        try:
+            stream = conn.open_stream()
+            if not stream.send_nowait(encoded_msg, frame_type=FrameType.CONCLUSION):
+                outbound_queue_size = conn._pending_outbound_frames.qsize()
+                remote_address = conn.remote_address
+                conn.close()
+                logger.warning(
+                    "Dropped slow client during global broadcast: "
+                    f"remote_address={remote_address}, "
+                    f"outbound_queue_size={outbound_queue_size}"
+                )
+        except ConnectionClosedError:
+            continue
+        except ConnectionError as e:
+            logger.warning(f"Failed to forward global broadcast: {e}")
+        except Exception:
+            logger.exception("Failed to forward global broadcast")

--- a/src/include/domains/operations/broadcast.py
+++ b/src/include/domains/operations/broadcast.py
@@ -11,7 +11,7 @@ def on_global_broadcast(msg: str):
     for conn in clients_copy:
         if conn._ws.protocol.state.name == "OPEN":
             try:
-                stream = conn.create_stream()
+                stream = conn.open_stream()
                 if not stream.send_nowait(encoded_msg, frame_type=FrameType.CONCLUSION):
                     outbound_queue = getattr(conn, "_outbound", None)
                     outbound_queue_size = (

--- a/src/include/shared.py
+++ b/src/include/shared.py
@@ -7,9 +7,9 @@ __all__ = ["clients", "clients_lock", "lockdown_enabled"]
 import threading
 
 from include.providers.manager import ProviderManager
-from include.transport.multiplexing import MultiplexConnection
+from include.transport.multiplexing import MultiplexedConnection
 
-clients: set[MultiplexConnection] = set()
+clients: set[MultiplexedConnection] = set()
 clients_lock = threading.Lock()
 
 

--- a/src/include/transport/connection.py
+++ b/src/include/transport/connection.py
@@ -6,10 +6,14 @@ from typing import Optional
 
 import jsonschema
 import orjson
-import websockets
 from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes
 from loguru import logger as log
+from websockets.exceptions import (
+    ConnectionClosed,
+    ConnectionClosedError,
+    ConnectionClosedOK,
+)
 from websockets.typing import Data
 
 from include.config.constants import (
@@ -336,8 +340,8 @@ class ConnectionHandler:
             )
 
         except (
-            websockets.ConnectionClosed,
-            websockets.exceptions.ConnectionClosedError,
+            ConnectionClosed,
+            ConnectionClosedError,
         ):
             self.logger.info("File transmission aborted: Connection closed")
             return
@@ -479,8 +483,8 @@ class ConnectionHandler:
                         if len(data) < chunk_size:
                             break
                 except (
-                    websockets.ConnectionClosed,
-                    websockets.exceptions.ConnectionClosedOK,
+                    ConnectionClosed,
+                    ConnectionClosedOK,
                 ):
                     raise
 

--- a/src/include/transport/multiplexing.py
+++ b/src/include/transport/multiplexing.py
@@ -1,9 +1,9 @@
 import queue
 import struct
 import threading
+import time
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Optional
 
 import websockets
 from loguru import logger as log
@@ -11,8 +11,10 @@ from websockets.sync.server import ServerConnection
 from websockets.typing import Data
 
 HEADER_FORMAT = "!IB"  # 4 bytes for frame_id, 1 byte for frame_type
-HEADER_SIZE = struct.calcsize(HEADER_FORMAT)
+HEADER = struct.Struct(HEADER_FORMAT)
+HEADER_SIZE = HEADER.size
 OUTBOUND_QUEUE_SIZE = 1024
+QUEUE_POLL_INTERVAL = 0.05
 
 logger = log.bind(name="multiplexer")
 
@@ -22,18 +24,18 @@ class FrameType(IntEnum):
     CONCLUSION = 1
 
 
-@dataclass
+@dataclass(slots=True)
 class Frame:
     frame_id: int
     frame_type: FrameType
     data: bytes | memoryview  # can't be str
 
 
-@dataclass
+@dataclass(slots=True)
 class _OutboundFrame:
     payload: bytes
-    done: Optional[threading.Event] = None
-    exception: Optional[BaseException] = None
+    done: threading.Event | None = None
+    exception: BaseException | None = None
 
 
 class Stream:
@@ -56,14 +58,14 @@ class Stream:
             self.frame_id, frame_type, data, wait_for_write=False
         )
 
-    def recv(self, timeout: Optional[float] = None) -> Frame:
+    def recv(self, timeout: float | None = None) -> Frame:
         """Receive data for this stream, blocking until a frame is available."""
         frame = self._queue.get(timeout=timeout)
         if frame is None:
             raise ConnectionError("MultiplexConnection has been closed")
         return frame
 
-    def _put_incoming_frame(self, frame: Optional[Frame]):
+    def _put_incoming_frame(self, frame: Frame | None):
         """Queue a frame for this stream. Called by the dispatcher."""
         self._queue.put(frame)
 
@@ -82,11 +84,11 @@ class MultiplexConnection:
         self._streams: dict[int, Stream] = {}
         self._streams_lock = threading.Lock()
 
-        self._new_streams: queue.Queue[Optional[Stream]] = queue.Queue()
-        self._outbound: queue.Queue[Optional[_OutboundFrame]] = queue.Queue(
+        self._new_streams: queue.Queue[Stream | None] = queue.Queue()
+        self._outbound: queue.Queue[_OutboundFrame | None] = queue.Queue(
             OUTBOUND_QUEUE_SIZE
         )
-        self._send_error: Optional[BaseException] = None
+        self._send_error: BaseException | None = None
 
         self._is_running = True
         self._dispatcher = threading.Thread(target=self._recv_loop, daemon=True)
@@ -106,7 +108,7 @@ class MultiplexConnection:
 
         return new_stream
 
-    def accept_stream(self) -> Optional[Stream]:
+    def accept_stream(self) -> Stream | None:
         """Wait for and return a new stream created by the peer."""
         return self._new_streams.get()
 
@@ -115,15 +117,13 @@ class MultiplexConnection:
             while self._is_running:
                 raw_payload = self._ws.recv()
 
-                if len(raw_payload) < HEADER_SIZE:
-                    continue
-
                 if isinstance(raw_payload, str):
                     raw_payload = raw_payload.encode("utf-8")
 
-                frame_id, frame_type_val = struct.unpack_from(
-                    HEADER_FORMAT, raw_payload
-                )
+                if len(raw_payload) < HEADER_SIZE:
+                    continue
+
+                frame_id, frame_type_val = HEADER.unpack_from(raw_payload)
                 data = memoryview(raw_payload)[HEADER_SIZE:]
 
                 try:
@@ -132,6 +132,7 @@ class MultiplexConnection:
                     continue
 
                 frame = Frame(frame_id=frame_id, frame_type=frame_type, data=data)
+                close_for_protocol_error = False
 
                 with self._streams_lock:
                     if frame.frame_id not in self._streams:
@@ -140,19 +141,24 @@ class MultiplexConnection:
                                 f"({self.remote_address[0]}): Client attempted to "
                                 f"open server-reserved stream id {frame.frame_id}"
                             )
-                            self._ws.close(
-                                code=1002,
-                                reason=(
-                                    "Protocol error: invalid client-initiated stream"
-                                ),
-                            )
-                            return
-                        # Notify the local main thread about the peer stream.
-                        new_stream = Stream(self, frame.frame_id)
-                        self._streams[frame.frame_id] = new_stream
-                        self._new_streams.put(new_stream)
+                            close_for_protocol_error = True
+                        else:
+                            # Notify the local main thread about the peer stream.
+                            new_stream = Stream(self, frame.frame_id)
+                            self._streams[frame.frame_id] = new_stream
+                            self._new_streams.put(new_stream)
 
-                    target_stream = self._streams[frame.frame_id]
+                    target_stream = self._streams.get(frame.frame_id)
+
+                if close_for_protocol_error:
+                    self._ws.close(
+                        code=1002,
+                        reason="Protocol error: invalid client-initiated stream",
+                    )
+                    return
+
+                if target_stream is None:
+                    continue
 
                 target_stream._put_incoming_frame(frame)
 
@@ -177,15 +183,12 @@ class MultiplexConnection:
     def _encode_frame(self, frame_id: int, frame_type: FrameType, data: Data) -> bytes:
         if isinstance(data, str):
             data = data.encode("utf-8")
+        elif isinstance(data, memoryview):
+            data = data.tobytes()
+        elif isinstance(data, bytearray):
+            data = bytes(data)
 
-        data_len = len(data)
-        payload = bytearray(HEADER_SIZE + data_len)
-
-        struct.pack_into(HEADER_FORMAT, payload, 0, frame_id, frame_type.value)
-
-        payload[HEADER_SIZE:] = data
-
-        return bytes(payload)
+        return HEADER.pack(frame_id, frame_type.value) + data
 
     def _enqueue_frame(
         self,
@@ -194,8 +197,34 @@ class MultiplexConnection:
         data: Data,
         *,
         wait_for_write: bool = True,
-        timeout: Optional[float] = None,
+        timeout: float | None = None,
     ) -> bool:
+        if not self._check_send_state(wait_for_write=wait_for_write):
+            return False
+
+        item = _OutboundFrame(
+            payload=self._encode_frame(frame_id, frame_type, data),
+            done=threading.Event() if wait_for_write else None,
+        )
+
+        if wait_for_write:
+            self._put_outbound(item, timeout=timeout)
+        else:
+            try:
+                self._outbound.put_nowait(item)
+            except queue.Full:
+                return False
+
+        if item.done is None:
+            return True
+
+        self._wait_for_write(item)
+        if item.exception is not None:
+            raise ConnectionError("Failed to send WebSocket frame") from item.exception
+
+        return True
+
+    def _check_send_state(self, *, wait_for_write: bool) -> bool:
         if not self._is_running:
             if wait_for_write:
                 raise ConnectionError("MultiplexConnection has been closed")
@@ -208,29 +237,36 @@ class MultiplexConnection:
                 )
             return False
 
-        item = _OutboundFrame(
-            payload=self._encode_frame(frame_id, frame_type, data),
-            done=threading.Event() if wait_for_write else None,
-        )
-
-        try:
-            if wait_for_write:
-                self._outbound.put(item, timeout=timeout)
-            else:
-                self._outbound.put_nowait(item)
-        except queue.Full:
-            if wait_for_write:
-                raise TimeoutError("Timed out while queueing WebSocket frame")
-            return False
-
-        if item.done is None:
-            return True
-
-        item.done.wait()
-        if item.exception is not None:
-            raise ConnectionError("Failed to send WebSocket frame") from item.exception
-
         return True
+
+    def _put_outbound(
+        self, item: _OutboundFrame, *, timeout: float | None = None
+    ) -> None:
+        deadline = None if timeout is None else time.monotonic() + timeout
+
+        while True:
+            self._check_send_state(wait_for_write=True)
+            put_timeout = QUEUE_POLL_INTERVAL
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TimeoutError("Timed out while queueing WebSocket frame")
+                put_timeout = min(put_timeout, remaining)
+
+            try:
+                self._outbound.put(item, timeout=put_timeout)
+                return
+            except queue.Full:
+                continue
+
+    def _wait_for_write(self, item: _OutboundFrame) -> None:
+        while item.done is not None and not item.done.wait(QUEUE_POLL_INTERVAL):
+            if self._send_error is not None:
+                item.exception = self._send_error
+                return
+            if not self._is_running:
+                item.exception = ConnectionError("MultiplexConnection has been closed")
+                return
 
     def _send_frame(
         self,

--- a/src/include/transport/multiplexing.py
+++ b/src/include/transport/multiplexing.py
@@ -19,6 +19,50 @@ QUEUE_POLL_INTERVAL = 0.05
 logger = log.bind(name="multiplexer")
 
 
+class ConnectionClosedError(ConnectionError):
+    """Raised when an operation is attempted after the connection closed."""
+
+    def __init__(self, message: str = "Connection has been closed") -> None:
+        super().__init__(message)
+
+
+class InvalidFrameError(Exception):
+    """Raised when a frame is invalid or cannot be decoded."""
+
+    close_code = 1002
+    close_reason = "Protocol error: invalid frame"
+
+
+class InvalidFrameTypeError(InvalidFrameError):
+    """Raised when a frame has an invalid type."""
+
+    def __init__(
+        self,
+        stream_id: int,
+        frame_type_value: int,
+        valid_frame_type_values: tuple[int, ...],
+    ) -> None:
+        self.stream_id = stream_id
+        self.frame_type_value = frame_type_value
+        self.valid_frame_type_values = valid_frame_type_values
+        super().__init__(
+            f"Invalid frame type {frame_type_value} for stream {stream_id}; "
+            f"expected one of {', '.join(map(str, valid_frame_type_values))}"
+        )
+
+
+class CorruptedFrameError(InvalidFrameError):
+    """Raised when a payload cannot contain a complete frame header."""
+
+    def __init__(self, actual_size: int, minimum_size: int) -> None:
+        self.actual_size = actual_size
+        self.minimum_size = minimum_size
+        super().__init__(
+            f"Frame too short: {actual_size} bytes, "
+            f"expected at least {minimum_size} bytes"
+        )
+
+
 class FrameType(IntEnum):
     PROCESS = 0
     CONCLUSION = 1
@@ -55,18 +99,21 @@ def encode_frame(stream_id: int, frame_type: FrameType, data: DataLike) -> bytea
     return frame
 
 
-def decode_frame(raw_payload: Data) -> Frame | None:
+def decode_frame(raw_payload: Data) -> Frame:
     if isinstance(raw_payload, str):
         raw_payload = raw_payload.encode("utf-8")
 
     if len(raw_payload) < FRAME_HEADER_SIZE:
-        return None
+        raise CorruptedFrameError(len(raw_payload), FRAME_HEADER_SIZE)
 
     stream_id, frame_type_val = FRAME_HEADER.unpack_from(raw_payload)
     try:
         frame_type = FrameType(frame_type_val)
-    except ValueError:
-        return None
+    except ValueError as exc:
+        valid_frame_type_values = tuple(frame_type.value for frame_type in FrameType)
+        raise InvalidFrameTypeError(
+            stream_id, frame_type_val, valid_frame_type_values
+        ) from exc
 
     return Frame(
         stream_id=stream_id,
@@ -105,7 +152,7 @@ class Stream:
             ) from exc
 
         if frame is None:
-            raise ConnectionError("Connection has been closed")
+            raise ConnectionClosedError
         return frame
 
     def _put_incoming_frame(self, frame: Frame | None) -> None:
@@ -152,7 +199,7 @@ class MultiplexedConnection:
     def open_stream(self) -> Stream:
         """Initiate a new data stream."""
         with self._send_state_lock:
-            self._check_send_state(wait_for_write=True)
+            self._raise_if_send_unavailable()
 
             with self._id_lock:
                 frame_id = self._next_frame_id
@@ -173,8 +220,6 @@ class MultiplexedConnection:
             while self._is_running:
                 raw_payload = self._ws.recv(decode=False)
                 frame = decode_frame(raw_payload)
-                if frame is None:
-                    continue
 
                 close_for_protocol_error = False
 
@@ -211,6 +256,9 @@ class MultiplexedConnection:
                     with self._streams_lock:
                         self._streams.pop(frame.stream_id, None)
 
+        except InvalidFrameError as exc:
+            logger.warning(f"({self.remote_address[0]}): Invalid frame: {exc}")
+            self._ws.close(code=exc.close_code, reason=exc.close_reason)
         except ConnectionClosed:
             logger.info(f"({self.remote_address[0]}): WebSocket connection closed")
         except Exception:
@@ -244,7 +292,7 @@ class MultiplexedConnection:
             self._put_outbound(item, timeout=timeout)
         else:
             with self._send_state_lock:
-                if not self._check_send_state(wait_for_write=False):
+                if not self._can_send_nowait():
                     return False
 
                 try:
@@ -261,20 +309,15 @@ class MultiplexedConnection:
 
         return True
 
-    def _check_send_state(self, *, wait_for_write: bool) -> bool:
+    def _raise_if_send_unavailable(self) -> None:
         if not self._is_running:
-            if wait_for_write:
-                raise ConnectionError("Connection has been closed")
-            return False
+            raise ConnectionClosedError
 
         if self._writer_error is not None:
-            if wait_for_write:
-                raise ConnectionError("Connection send loop failed") from (
-                    self._writer_error
-                )
-            return False
+            raise ConnectionError("Connection send loop failed") from self._writer_error
 
-        return True
+    def _can_send_nowait(self) -> bool:
+        return self._is_running and self._writer_error is None
 
     def _put_outbound(
         self, item: _OutboundFrame, *, timeout: float | None = None
@@ -290,7 +333,7 @@ class MultiplexedConnection:
                 put_timeout = min(put_timeout, remaining)
 
             with self._send_state_lock:
-                self._check_send_state(wait_for_write=True)
+                self._raise_if_send_unavailable()
                 try:
                     self._pending_outbound_frames.put(item, timeout=put_timeout)
                     return
@@ -303,9 +346,7 @@ class MultiplexedConnection:
                 item.exception = self._writer_error
                 return
             if not self._is_running:
-                item.exception = ConnectionError(
-                    "MultiplexedConnection has been closed"
-                )
+                item.exception = ConnectionClosedError()
                 return
 
     def _send_frame(
@@ -335,7 +376,7 @@ class MultiplexedConnection:
 
                 try:
                     if not self._is_running:
-                        raise ConnectionError("Connection has been closed")
+                        raise ConnectionClosedError
                     self._ws.send(item.payload)
                 except Exception as exc:
                     item.exception = exc
@@ -355,9 +396,7 @@ class MultiplexedConnection:
                 if item.done is not None:
                     item.done.set()
         finally:
-            error = self._writer_error or ConnectionError(
-                "Connection send loop stopped"
-            )
+            error = self._writer_error or ConnectionClosedError()
             self._fail_pending_sends(error)
 
     def _fail_pending_sends(self, exc: Exception) -> None:
@@ -377,7 +416,7 @@ class MultiplexedConnection:
     def close(self) -> None:
         with self._send_state_lock:
             self._is_running = False
-            self._fail_pending_sends(ConnectionError("Closing connection"))
+            self._fail_pending_sends(ConnectionClosedError("Connection is closing"))
             try:
                 self._pending_outbound_frames.put_nowait(None)
             except queue.Full:

--- a/src/include/transport/multiplexing.py
+++ b/src/include/transport/multiplexing.py
@@ -264,7 +264,8 @@ class MultiplexedConnection:
         except Exception:
             logger.exception(f"({self.remote_address[0]}): Error in receive loop")
         finally:
-            self._is_running = False
+            with self._send_state_lock:
+                self._is_running = False
             self._pending_inbound_streams.put(
                 None
             )  # Wake threads blocked in accept_stream.

--- a/src/include/transport/multiplexing.py
+++ b/src/include/transport/multiplexing.py
@@ -20,7 +20,7 @@ logger = log.bind(name="multiplexer")
 
 
 class FrameType(IntEnum):
-    DATA = 0
+    PROCESS = 0
     CONCLUSION = 1
 
 
@@ -35,7 +35,7 @@ class Frame:
 class _OutboundFrame:
     payload: bytearray
     done: threading.Event | None = None
-    exception: BaseException | None = None
+    exception: Exception | None = None
 
 
 def normalize_payload(data: DataLike) -> bytes | bytearray | memoryview:
@@ -83,12 +83,12 @@ class Stream:
         self.frame_id = frame_id
         self._queue: queue.Queue[Frame | None] = queue.Queue(100)
 
-    def send(self, data: DataLike, frame_type: FrameType = FrameType.DATA) -> None:
+    def send(self, data: DataLike, frame_type: FrameType = FrameType.PROCESS) -> None:
         """Send data on this stream."""
         self.connection._send_frame(self.frame_id, frame_type, data)
 
     def send_nowait(
-        self, data: DataLike, frame_type: FrameType = FrameType.DATA
+        self, data: DataLike, frame_type: FrameType = FrameType.PROCESS
     ) -> bool:
         """Queue data for sending without waiting for socket I/O."""
         return self.connection._send_frame(
@@ -105,7 +105,7 @@ class Stream:
             ) from exc
 
         if frame is None:
-            raise ConnectionError("MultiplexedConnection has been closed")
+            raise ConnectionError("Connection has been closed")
         return frame
 
     def _put_incoming_frame(self, frame: Frame | None) -> None:
@@ -127,14 +127,23 @@ class MultiplexedConnection:
         self._streams: dict[int, Stream] = {}
         self._streams_lock = threading.Lock()
 
-        self._new_streams: queue.Queue[Stream | None] = queue.Queue()
-        self._outbound: queue.Queue[_OutboundFrame | None] = queue.Queue(
+        # Pending queue for inbound streams.
+        self._pending_inbound_streams: queue.Queue[Stream | None] = queue.Queue()
+
+        # Pending queue for outbound frames.
+        #
+        # The reason for setting up a queue for outbound frames but not for streams is
+        # that the send loop is responsible for determining which stream to send the
+        # frame to.
+        self._pending_outbound_frames: queue.Queue[_OutboundFrame | None] = queue.Queue(
             OUTBOUND_QUEUE_SIZE
         )
-        self._writer_error: BaseException | None = None
+
+        self._writer_error: Exception | None = None
         self._send_state_lock = threading.Lock()
 
         self._is_running = True
+
         self._dispatcher = threading.Thread(target=self._recv_loop, daemon=True)
         self._dispatcher.start()
         self._writer = threading.Thread(target=self._send_loop, daemon=True)
@@ -157,7 +166,7 @@ class MultiplexedConnection:
 
     def accept_stream(self) -> Stream | None:
         """Wait for and return a new stream created by the peer."""
-        return self._new_streams.get()
+        return self._pending_inbound_streams.get()
 
     def _recv_loop(self) -> None:
         try:
@@ -182,7 +191,7 @@ class MultiplexedConnection:
                             # Notify the local main thread about the peer stream.
                             new_stream = Stream(self, frame.stream_id)
                             self._streams[frame.stream_id] = new_stream
-                            self._new_streams.put(new_stream)
+                            self._pending_inbound_streams.put(new_stream)
                             target_stream = new_stream
 
                 if close_for_protocol_error:
@@ -208,7 +217,9 @@ class MultiplexedConnection:
             logger.exception(f"({self.remote_address[0]}): Error in receive loop")
         finally:
             self._is_running = False
-            self._new_streams.put(None)  # Wake threads blocked in accept_stream.
+            self._pending_inbound_streams.put(
+                None
+            )  # Wake threads blocked in accept_stream.
 
             # Wake all threads blocked in Stream.recv() to prevent deadlocks.
             with self._streams_lock:
@@ -237,7 +248,7 @@ class MultiplexedConnection:
                     return False
 
                 try:
-                    self._outbound.put_nowait(item)
+                    self._pending_outbound_frames.put_nowait(item)
                 except queue.Full:
                     return False
 
@@ -253,12 +264,12 @@ class MultiplexedConnection:
     def _check_send_state(self, *, wait_for_write: bool) -> bool:
         if not self._is_running:
             if wait_for_write:
-                raise ConnectionError("MultiplexedConnection has been closed")
+                raise ConnectionError("Connection has been closed")
             return False
 
         if self._writer_error is not None:
             if wait_for_write:
-                raise ConnectionError("MultiplexedConnection send loop failed") from (
+                raise ConnectionError("Connection send loop failed") from (
                     self._writer_error
                 )
             return False
@@ -281,7 +292,7 @@ class MultiplexedConnection:
             with self._send_state_lock:
                 self._check_send_state(wait_for_write=True)
                 try:
-                    self._outbound.put(item, timeout=put_timeout)
+                    self._pending_outbound_frames.put(item, timeout=put_timeout)
                     return
                 except queue.Full:
                     continue
@@ -318,13 +329,13 @@ class MultiplexedConnection:
     def _send_loop(self) -> None:
         try:
             while True:
-                item = self._outbound.get()
+                item = self._pending_outbound_frames.get()
                 if item is None:
                     return
 
                 try:
                     if not self._is_running:
-                        raise ConnectionError("MultiplexedConnection has been closed")
+                        raise ConnectionError("Connection has been closed")
                     self._ws.send(item.payload)
                 except Exception as exc:
                     item.exception = exc
@@ -345,14 +356,14 @@ class MultiplexedConnection:
                     item.done.set()
         finally:
             error = self._writer_error or ConnectionError(
-                "MultiplexedConnection send loop stopped"
+                "Connection send loop stopped"
             )
             self._fail_pending_sends(error)
 
-    def _fail_pending_sends(self, exc: BaseException) -> None:
+    def _fail_pending_sends(self, exc: Exception) -> None:
         while True:
             try:
-                item = self._outbound.get_nowait()
+                item = self._pending_outbound_frames.get_nowait()
             except queue.Empty:
                 return
 
@@ -364,12 +375,11 @@ class MultiplexedConnection:
                 item.done.set()
 
     def close(self) -> None:
-        close_error = ConnectionError("MultiplexedConnection has been closed")
         with self._send_state_lock:
             self._is_running = False
-            self._fail_pending_sends(close_error)
+            self._fail_pending_sends(ConnectionError("Closing connection"))
             try:
-                self._outbound.put_nowait(None)
+                self._pending_outbound_frames.put_nowait(None)
             except queue.Full:
                 # Pending senders were already failed; closing must not block.
                 pass

--- a/src/include/transport/multiplexing.py
+++ b/src/include/transport/multiplexing.py
@@ -5,10 +5,10 @@ import time
 from dataclasses import dataclass
 from enum import IntEnum
 
-import websockets
 from loguru import logger as log
+from websockets.exceptions import ConnectionClosed
 from websockets.sync.server import ServerConnection
-from websockets.typing import DataLike
+from websockets.typing import Data, DataLike
 
 FRAME_HEADER_FORMAT = "!IB"  # 4 bytes for stream_id, 1 byte for frame_type
 FRAME_HEADER = struct.Struct(FRAME_HEADER_FORMAT)
@@ -36,6 +36,43 @@ class _OutboundFrame:
     payload: bytearray
     done: threading.Event | None = None
     exception: BaseException | None = None
+
+
+def normalize_payload(data: DataLike) -> bytes | bytearray | memoryview:
+    if isinstance(data, str):
+        return data.encode("utf-8")
+    if isinstance(data, (bytes, bytearray, memoryview)):
+        return data
+    raise TypeError("Frame data must be str, bytes, bytearray, or memoryview")
+
+
+def encode_frame(stream_id: int, frame_type: FrameType, data: DataLike) -> bytearray:
+    payload = normalize_payload(data)
+    frame = bytearray(FRAME_HEADER_SIZE + len(payload))
+    FRAME_HEADER.pack_into(frame, 0, stream_id, frame_type.value)
+    frame[FRAME_HEADER_SIZE:] = payload
+
+    return frame
+
+
+def decode_frame(raw_payload: Data) -> Frame | None:
+    if isinstance(raw_payload, str):
+        raw_payload = raw_payload.encode("utf-8")
+
+    if len(raw_payload) < FRAME_HEADER_SIZE:
+        return None
+
+    stream_id, frame_type_val = FRAME_HEADER.unpack_from(raw_payload)
+    try:
+        frame_type = FrameType(frame_type_val)
+    except ValueError:
+        return None
+
+    return Frame(
+        stream_id=stream_id,
+        frame_type=frame_type,
+        data=memoryview(raw_payload)[FRAME_HEADER_SIZE:],
+    )
 
 
 class Stream:
@@ -125,38 +162,26 @@ class MultiplexedConnection:
     def _recv_loop(self) -> None:
         try:
             while self._is_running:
-                raw_payload = self._ws.recv()
-
-                if isinstance(raw_payload, str):
-                    raw_payload = raw_payload.encode("utf-8")
-
-                if len(raw_payload) < FRAME_HEADER_SIZE:
+                raw_payload = self._ws.recv(decode=False)
+                frame = decode_frame(raw_payload)
+                if frame is None:
                     continue
 
-                stream_id, frame_type_val = FRAME_HEADER.unpack_from(raw_payload)
-                data = memoryview(raw_payload)[FRAME_HEADER_SIZE:]
-
-                try:
-                    frame_type = FrameType(frame_type_val)
-                except ValueError:
-                    continue
-
-                frame = Frame(stream_id=stream_id, frame_type=frame_type, data=data)
                 close_for_protocol_error = False
 
                 with self._streams_lock:
-                    target_stream = self._streams.get(stream_id)
+                    target_stream = self._streams.get(frame.stream_id)
                     if target_stream is None:
-                        if stream_id % 2 == 0:
+                        if frame.stream_id % 2 == 0:
                             logger.warning(
                                 f"({self.remote_address[0]}): Client attempted to "
-                                f"open server-reserved stream id {stream_id}"
+                                f"open server-reserved stream id {frame.stream_id}"
                             )
                             close_for_protocol_error = True
                         else:
                             # Notify the local main thread about the peer stream.
-                            new_stream = Stream(self, stream_id)
-                            self._streams[stream_id] = new_stream
+                            new_stream = Stream(self, frame.stream_id)
+                            self._streams[frame.stream_id] = new_stream
                             self._new_streams.put(new_stream)
                             target_stream = new_stream
 
@@ -175,9 +200,9 @@ class MultiplexedConnection:
                 # Reclaim routing table memory when the peer sends an end frame.
                 if frame.frame_type == FrameType.CONCLUSION:
                     with self._streams_lock:
-                        self._streams.pop(stream_id, None)
+                        self._streams.pop(frame.stream_id, None)
 
-        except websockets.exceptions.ConnectionClosed:
+        except ConnectionClosed:
             logger.info(f"({self.remote_address[0]}): WebSocket connection closed")
         except Exception:
             logger.exception(f"({self.remote_address[0]}): Error in receive loop")
@@ -190,24 +215,6 @@ class MultiplexedConnection:
                 for stream in self._streams.values():
                     stream._put_incoming_frame(None)
 
-    @staticmethod
-    def _normalize_payload(data: DataLike) -> bytes | bytearray | memoryview:
-        if isinstance(data, str):
-            return data.encode("utf-8")
-        if isinstance(data, (bytes, bytearray, memoryview)):
-            return data
-        raise TypeError("Frame data must be str, bytes, bytearray, or memoryview")
-
-    def _encode_frame(
-        self, frame_id: int, frame_type: FrameType, data: DataLike
-    ) -> bytearray:
-        payload = self._normalize_payload(data)
-        frame = bytearray(FRAME_HEADER_SIZE + len(payload))
-        FRAME_HEADER.pack_into(frame, 0, frame_id, frame_type.value)
-        frame[FRAME_HEADER_SIZE:] = payload
-
-        return frame
-
     def _enqueue_frame(
         self,
         frame_id: int,
@@ -218,7 +225,7 @@ class MultiplexedConnection:
         timeout: float | None = None,
     ) -> bool:
         item = _OutboundFrame(
-            payload=self._encode_frame(frame_id, frame_type, data),
+            payload=encode_frame(frame_id, frame_type, data),
             done=threading.Event() if wait_for_write else None,
         )
 

--- a/src/include/transport/multiplexing.py
+++ b/src/include/transport/multiplexing.py
@@ -8,11 +8,11 @@ from enum import IntEnum
 import websockets
 from loguru import logger as log
 from websockets.sync.server import ServerConnection
-from websockets.typing import Data
+from websockets.typing import DataLike
 
-HEADER_FORMAT = "!IB"  # 4 bytes for frame_id, 1 byte for frame_type
-HEADER = struct.Struct(HEADER_FORMAT)
-HEADER_SIZE = HEADER.size
+FRAME_HEADER_FORMAT = "!IB"  # 4 bytes for stream_id, 1 byte for frame_type
+FRAME_HEADER = struct.Struct(FRAME_HEADER_FORMAT)
+FRAME_HEADER_SIZE = FRAME_HEADER.size
 OUTBOUND_QUEUE_SIZE = 1024
 QUEUE_POLL_INTERVAL = 0.05
 
@@ -20,20 +20,20 @@ logger = log.bind(name="multiplexer")
 
 
 class FrameType(IntEnum):
-    PROCESS = 0
+    DATA = 0
     CONCLUSION = 1
 
 
 @dataclass(slots=True)
 class Frame:
-    frame_id: int
+    stream_id: int
     frame_type: FrameType
     data: bytes | memoryview  # can't be str
 
 
 @dataclass(slots=True)
 class _OutboundFrame:
-    payload: bytes
+    payload: bytearray
     done: threading.Event | None = None
     exception: BaseException | None = None
 
@@ -41,17 +41,17 @@ class _OutboundFrame:
 class Stream:
     """Represent an independent communication stream, like a virtual connection."""
 
-    def __init__(self, connection: "MultiplexConnection", frame_id: int):
+    def __init__(self, connection: "MultiplexedConnection", frame_id: int) -> None:
         self.connection = connection
         self.frame_id = frame_id
-        self._queue: queue.Queue = queue.Queue(100)
+        self._queue: queue.Queue[Frame | None] = queue.Queue(100)
 
-    def send(self, data: Data, frame_type: FrameType = FrameType.PROCESS):
+    def send(self, data: DataLike, frame_type: FrameType = FrameType.DATA) -> None:
         """Send data on this stream."""
         self.connection._send_frame(self.frame_id, frame_type, data)
 
     def send_nowait(
-        self, data: Data, frame_type: FrameType = FrameType.PROCESS
+        self, data: DataLike, frame_type: FrameType = FrameType.DATA
     ) -> bool:
         """Queue data for sending without waiting for socket I/O."""
         return self.connection._send_frame(
@@ -60,18 +60,24 @@ class Stream:
 
     def recv(self, timeout: float | None = None) -> Frame:
         """Receive data for this stream, blocking until a frame is available."""
-        frame = self._queue.get(timeout=timeout)
+        try:
+            frame = self._queue.get(timeout=timeout)
+        except queue.Empty as exc:
+            raise TimeoutError(
+                "Timed out while waiting for multiplexed stream frame"
+            ) from exc
+
         if frame is None:
-            raise ConnectionError("MultiplexConnection has been closed")
+            raise ConnectionError("MultiplexedConnection has been closed")
         return frame
 
-    def _put_incoming_frame(self, frame: Frame | None):
+    def _put_incoming_frame(self, frame: Frame | None) -> None:
         """Queue a frame for this stream. Called by the dispatcher."""
         self._queue.put(frame)
 
 
-class MultiplexConnection:
-    def __init__(self, websocket: ServerConnection):
+class MultiplexedConnection:
+    def __init__(self, websocket: ServerConnection) -> None:
         """
         :param websocket: ServerConnection
         """
@@ -88,7 +94,8 @@ class MultiplexConnection:
         self._outbound: queue.Queue[_OutboundFrame | None] = queue.Queue(
             OUTBOUND_QUEUE_SIZE
         )
-        self._send_error: BaseException | None = None
+        self._writer_error: BaseException | None = None
+        self._send_state_lock = threading.Lock()
 
         self._is_running = True
         self._dispatcher = threading.Thread(target=self._recv_loop, daemon=True)
@@ -96,15 +103,18 @@ class MultiplexConnection:
         self._writer = threading.Thread(target=self._send_loop, daemon=True)
         self._writer.start()
 
-    def create_stream(self) -> Stream:
+    def open_stream(self) -> Stream:
         """Initiate a new data stream."""
-        with self._id_lock:
-            frame_id = self._next_frame_id
-            self._next_frame_id += 2  # Preserve parity.
+        with self._send_state_lock:
+            self._check_send_state(wait_for_write=True)
 
-        new_stream = Stream(self, frame_id)
-        with self._streams_lock:
-            self._streams[frame_id] = new_stream
+            with self._id_lock:
+                frame_id = self._next_frame_id
+                self._next_frame_id += 2  # Preserve parity.
+
+            new_stream = Stream(self, frame_id)
+            with self._streams_lock:
+                self._streams[frame_id] = new_stream
 
         return new_stream
 
@@ -112,7 +122,7 @@ class MultiplexConnection:
         """Wait for and return a new stream created by the peer."""
         return self._new_streams.get()
 
-    def _recv_loop(self):
+    def _recv_loop(self) -> None:
         try:
             while self._is_running:
                 raw_payload = self._ws.recv()
@@ -120,35 +130,35 @@ class MultiplexConnection:
                 if isinstance(raw_payload, str):
                     raw_payload = raw_payload.encode("utf-8")
 
-                if len(raw_payload) < HEADER_SIZE:
+                if len(raw_payload) < FRAME_HEADER_SIZE:
                     continue
 
-                frame_id, frame_type_val = HEADER.unpack_from(raw_payload)
-                data = memoryview(raw_payload)[HEADER_SIZE:]
+                stream_id, frame_type_val = FRAME_HEADER.unpack_from(raw_payload)
+                data = memoryview(raw_payload)[FRAME_HEADER_SIZE:]
 
                 try:
                     frame_type = FrameType(frame_type_val)
                 except ValueError:
                     continue
 
-                frame = Frame(frame_id=frame_id, frame_type=frame_type, data=data)
+                frame = Frame(stream_id=stream_id, frame_type=frame_type, data=data)
                 close_for_protocol_error = False
 
                 with self._streams_lock:
-                    if frame.frame_id not in self._streams:
-                        if frame.frame_id % 2 == 0:
+                    target_stream = self._streams.get(stream_id)
+                    if target_stream is None:
+                        if stream_id % 2 == 0:
                             logger.warning(
                                 f"({self.remote_address[0]}): Client attempted to "
-                                f"open server-reserved stream id {frame.frame_id}"
+                                f"open server-reserved stream id {stream_id}"
                             )
                             close_for_protocol_error = True
                         else:
                             # Notify the local main thread about the peer stream.
-                            new_stream = Stream(self, frame.frame_id)
-                            self._streams[frame.frame_id] = new_stream
+                            new_stream = Stream(self, stream_id)
+                            self._streams[stream_id] = new_stream
                             self._new_streams.put(new_stream)
-
-                    target_stream = self._streams.get(frame.frame_id)
+                            target_stream = new_stream
 
                 if close_for_protocol_error:
                     self._ws.close(
@@ -165,7 +175,7 @@ class MultiplexConnection:
                 # Reclaim routing table memory when the peer sends an end frame.
                 if frame.frame_type == FrameType.CONCLUSION:
                     with self._streams_lock:
-                        self._streams.pop(frame.frame_id, None)
+                        self._streams.pop(stream_id, None)
 
         except websockets.exceptions.ConnectionClosed:
             logger.info(f"({self.remote_address[0]}): WebSocket connection closed")
@@ -180,28 +190,33 @@ class MultiplexConnection:
                 for stream in self._streams.values():
                     stream._put_incoming_frame(None)
 
-    def _encode_frame(self, frame_id: int, frame_type: FrameType, data: Data) -> bytes:
+    @staticmethod
+    def _normalize_payload(data: DataLike) -> bytes | bytearray | memoryview:
         if isinstance(data, str):
-            data = data.encode("utf-8")
-        elif isinstance(data, memoryview):
-            data = data.tobytes()
-        elif isinstance(data, bytearray):
-            data = bytes(data)
+            return data.encode("utf-8")
+        if isinstance(data, (bytes, bytearray, memoryview)):
+            return data
+        raise TypeError("Frame data must be str, bytes, bytearray, or memoryview")
 
-        return HEADER.pack(frame_id, frame_type.value) + data
+    def _encode_frame(
+        self, frame_id: int, frame_type: FrameType, data: DataLike
+    ) -> bytearray:
+        payload = self._normalize_payload(data)
+        frame = bytearray(FRAME_HEADER_SIZE + len(payload))
+        FRAME_HEADER.pack_into(frame, 0, frame_id, frame_type.value)
+        frame[FRAME_HEADER_SIZE:] = payload
+
+        return frame
 
     def _enqueue_frame(
         self,
         frame_id: int,
         frame_type: FrameType,
-        data: Data,
+        data: DataLike,
         *,
         wait_for_write: bool = True,
         timeout: float | None = None,
     ) -> bool:
-        if not self._check_send_state(wait_for_write=wait_for_write):
-            return False
-
         item = _OutboundFrame(
             payload=self._encode_frame(frame_id, frame_type, data),
             done=threading.Event() if wait_for_write else None,
@@ -210,10 +225,14 @@ class MultiplexConnection:
         if wait_for_write:
             self._put_outbound(item, timeout=timeout)
         else:
-            try:
-                self._outbound.put_nowait(item)
-            except queue.Full:
-                return False
+            with self._send_state_lock:
+                if not self._check_send_state(wait_for_write=False):
+                    return False
+
+                try:
+                    self._outbound.put_nowait(item)
+                except queue.Full:
+                    return False
 
         if item.done is None:
             return True
@@ -227,13 +246,13 @@ class MultiplexConnection:
     def _check_send_state(self, *, wait_for_write: bool) -> bool:
         if not self._is_running:
             if wait_for_write:
-                raise ConnectionError("MultiplexConnection has been closed")
+                raise ConnectionError("MultiplexedConnection has been closed")
             return False
 
-        if self._send_error is not None:
+        if self._writer_error is not None:
             if wait_for_write:
-                raise ConnectionError("MultiplexConnection send loop failed") from (
-                    self._send_error
+                raise ConnectionError("MultiplexedConnection send loop failed") from (
+                    self._writer_error
                 )
             return False
 
@@ -245,7 +264,6 @@ class MultiplexConnection:
         deadline = None if timeout is None else time.monotonic() + timeout
 
         while True:
-            self._check_send_state(wait_for_write=True)
             put_timeout = QUEUE_POLL_INTERVAL
             if deadline is not None:
                 remaining = deadline - time.monotonic()
@@ -253,26 +271,30 @@ class MultiplexConnection:
                     raise TimeoutError("Timed out while queueing WebSocket frame")
                 put_timeout = min(put_timeout, remaining)
 
-            try:
-                self._outbound.put(item, timeout=put_timeout)
-                return
-            except queue.Full:
-                continue
+            with self._send_state_lock:
+                self._check_send_state(wait_for_write=True)
+                try:
+                    self._outbound.put(item, timeout=put_timeout)
+                    return
+                except queue.Full:
+                    continue
 
     def _wait_for_write(self, item: _OutboundFrame) -> None:
         while item.done is not None and not item.done.wait(QUEUE_POLL_INTERVAL):
-            if self._send_error is not None:
-                item.exception = self._send_error
+            if self._writer_error is not None:
+                item.exception = self._writer_error
                 return
             if not self._is_running:
-                item.exception = ConnectionError("MultiplexConnection has been closed")
+                item.exception = ConnectionError(
+                    "MultiplexedConnection has been closed"
+                )
                 return
 
     def _send_frame(
         self,
         frame_id: int,
         frame_type: FrameType,
-        data: Data,
+        data: DataLike,
         *,
         wait_for_write: bool = True,
     ) -> bool:
@@ -286,7 +308,7 @@ class MultiplexConnection:
 
         return queued
 
-    def _send_loop(self):
+    def _send_loop(self) -> None:
         try:
             while True:
                 item = self._outbound.get()
@@ -295,15 +317,16 @@ class MultiplexConnection:
 
                 try:
                     if not self._is_running:
-                        raise ConnectionError("MultiplexConnection has been closed")
+                        raise ConnectionError("MultiplexedConnection has been closed")
                     self._ws.send(item.payload)
                 except Exception as exc:
-                    self._send_error = exc
-                    self._is_running = False
                     item.exception = exc
                     if item.done is not None:
                         item.done.set()
-                    self._fail_pending_sends(exc)
+                    with self._send_state_lock:
+                        self._writer_error = exc
+                        self._is_running = False
+                        self._fail_pending_sends(exc)
                     try:
                         self._ws.close()
                     except Exception:
@@ -314,12 +337,12 @@ class MultiplexConnection:
                 if item.done is not None:
                     item.done.set()
         finally:
-            error = self._send_error or ConnectionError(
-                "MultiplexConnection send loop stopped"
+            error = self._writer_error or ConnectionError(
+                "MultiplexedConnection send loop stopped"
             )
             self._fail_pending_sends(error)
 
-    def _fail_pending_sends(self, exc: BaseException):
+    def _fail_pending_sends(self, exc: BaseException) -> None:
         while True:
             try:
                 item = self._outbound.get_nowait()
@@ -333,14 +356,16 @@ class MultiplexConnection:
             if item.done is not None:
                 item.done.set()
 
-    def close(self):
-        self._is_running = False
-        self._fail_pending_sends(ConnectionError("MultiplexConnection has been closed"))
-        try:
-            self._outbound.put_nowait(None)
-        except queue.Full:
-            # Pending senders were already failed; closing must not block.
-            pass
+    def close(self) -> None:
+        close_error = ConnectionError("MultiplexedConnection has been closed")
+        with self._send_state_lock:
+            self._is_running = False
+            self._fail_pending_sends(close_error)
+            try:
+                self._outbound.put_nowait(None)
+            except queue.Full:
+                # Pending senders were already failed; closing must not block.
+                pass
         try:
             self._ws.close()
         except Exception:

--- a/src/include/transport/router.py
+++ b/src/include/transport/router.py
@@ -4,9 +4,9 @@ from typing import Optional
 
 import jsonschema
 import orjson
-import websockets
-import websockets.sync.server
 from loguru import logger as log
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
+from websockets.sync.server import ServerConnection
 
 from include.config.constants import NONCE_MIN_LENGTH
 from include.database.models.identity import User
@@ -252,7 +252,7 @@ def _validate_replay_protection(
     return None
 
 
-def handle_connection(websocket: websockets.sync.server.ServerConnection):
+def handle_connection(websocket: ServerConnection):
     """
     Handle incoming WebSocket connections.
 
@@ -416,8 +416,8 @@ def handle_request(stream: Stream):
                 time_cost=t2 - t1,
             )
         except (
-            websockets.exceptions.ConnectionClosedOK,
-            websockets.exceptions.ConnectionClosedError,
+            ConnectionClosedOK,
+            ConnectionClosedError,
         ):
             logger.info("WebSocket connection closed during request handling")
             return

--- a/src/include/transport/router.py
+++ b/src/include/transport/router.py
@@ -107,7 +107,7 @@ from include.extensions.manager import pm
 from include.shared import clients, clients_lock, lockdown_enabled
 from include.transport.client_address import get_client_ip
 from include.transport.connection import ConnectionHandler
-from include.transport.multiplexing import FrameType, MultiplexConnection, Stream
+from include.transport.multiplexing import FrameType, MultiplexedConnection, Stream
 from include.transport.request_handler import RequestHandler, Result
 
 logger = log.bind(name="connection_handler")
@@ -268,7 +268,7 @@ def handle_connection(websocket: websockets.sync.server.ServerConnection):
     else:
         logger.info(f"Incoming connection: {websocket.remote_address[0]}")
 
-    multiplexer = MultiplexConnection(websocket)
+    multiplexer = MultiplexedConnection(websocket)
 
     with clients_lock:
         clients.add(multiplexer)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -23,8 +23,9 @@ import orjson
 from Crypto.Cipher import AES
 from websockets.asyncio.client import ClientConnection, connect
 
-HEADER_FORMAT = "!IB"
-HEADER_SIZE = struct.calcsize(HEADER_FORMAT)
+FRAME_HEADER_FORMAT = "!IB"
+FRAME_HEADER = struct.Struct(FRAME_HEADER_FORMAT)
+FRAME_HEADER_SIZE = FRAME_HEADER.size
 
 
 def calculate_sha256(file_path: str) -> str:
@@ -46,13 +47,13 @@ def calculate_sha256(file_path: str) -> str:
 
 
 class FrameType(IntEnum):
-    PROCESS = 0
+    DATA = 0
     CONCLUSION = 1
 
 
 @dataclass
 class Frame:
-    frame_id: int
+    stream_id: int
     frame_type: FrameType
     data: Any
 
@@ -63,7 +64,7 @@ class AsyncStream:
         self.frame_id = frame_id
         self._queue: queue.Queue = queue.Queue(100)
 
-    async def send(self, data: Any, frame_type: FrameType = FrameType.PROCESS):
+    async def send(self, data: Any, frame_type: FrameType = FrameType.DATA):
         await self.connection._send_frame(self.frame_id, frame_type, data)
 
     async def recv(self, timeout: Optional[float] = None) -> Frame:
@@ -80,7 +81,7 @@ class AsyncStream:
             raise TimeoutError("Stream recv timeout")
 
         if frame is None:
-            raise ConnectionError("MultiplexConnection has been closed")
+            raise ConnectionError("MultiplexedConnection has been closed")
         return frame
 
     def _put_incoming_frame(self, frame: Optional[Frame]):
@@ -98,7 +99,7 @@ class AsyncMultiplexConnection:
         self._is_running = True
         self._dispatcher_task = asyncio.create_task(self._recv_loop())
 
-    def create_stream(self) -> AsyncStream:
+    def open_stream(self) -> AsyncStream:
         with self._id_lock:
             frame_id = self._next_frame_id
             self._next_frame_id += 2
@@ -130,38 +131,38 @@ class AsyncMultiplexConnection:
                 if isinstance(raw_payload, str):
                     raw_payload = raw_payload.encode("utf-8")
 
-                if len(raw_payload) < HEADER_SIZE:
+                if len(raw_payload) < FRAME_HEADER_SIZE:
                     continue
 
-                frame_id, frame_type_val = struct.unpack_from(
-                    HEADER_FORMAT, raw_payload
-                )
-                data_bytes = raw_payload[HEADER_SIZE:]
+                stream_id, frame_type_val = FRAME_HEADER.unpack_from(raw_payload)
+                data_bytes = raw_payload[FRAME_HEADER_SIZE:]
 
                 try:
                     frame_type = FrameType(frame_type_val)
                 except ValueError:
                     continue
 
-                frame = Frame(frame_id=frame_id, frame_type=frame_type, data=data_bytes)
+                frame = Frame(
+                    stream_id=stream_id, frame_type=frame_type, data=data_bytes
+                )
 
                 with self._streams_lock:
-                    if frame.frame_id not in self._streams:
-                        if frame.frame_id % 2 != 0:
+                    target_stream = self._streams.get(stream_id)
+                    if target_stream is None:
+                        if stream_id % 2 != 0:
                             self._is_running = False
                             await self._ws.close()
                             return
-                        new_stream = AsyncStream(self, frame.frame_id)
-                        self._streams[frame.frame_id] = new_stream
+                        new_stream = AsyncStream(self, stream_id)
+                        self._streams[stream_id] = new_stream
                         self._new_streams.put(new_stream)
-
-                    target_stream = self._streams[frame.frame_id]
+                        target_stream = new_stream
 
                 target_stream._put_incoming_frame(frame)
 
                 if frame.frame_type == FrameType.CONCLUSION:
                     with self._streams_lock:
-                        self._streams.pop(frame.frame_id, None)
+                        self._streams.pop(stream_id, None)
 
         except Exception:
             pass
@@ -178,15 +179,12 @@ class AsyncMultiplexConnection:
         elif isinstance(data, memoryview):
             data = data.tobytes()
 
-        if data is None:
-            data = b""
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            raise TypeError("Frame data must be str, bytes, bytearray, or memoryview")
 
-        if not isinstance(data, (bytes, bytearray)):
-            raise TypeError("Frame data must be bytes/string")
-
-        payload = bytearray(HEADER_SIZE + len(data))
-        struct.pack_into(HEADER_FORMAT, payload, 0, frame_id, frame_type.value)
-        payload[HEADER_SIZE:] = data
+        payload = bytearray(FRAME_HEADER_SIZE + len(data))
+        FRAME_HEADER.pack_into(payload, 0, frame_id, frame_type.value)
+        payload[FRAME_HEADER_SIZE:] = data
 
         await self._ws.send(payload)
 
@@ -392,7 +390,7 @@ class CFMSTestClient:
         if self.multiplexer is None:
             raise RuntimeError("Not connected to server. Call connect() first.")
 
-        stream = self.multiplexer.create_stream()
+        stream = self.multiplexer.open_stream()
         frame = await self._build_and_send_request(
             stream,
             action,
@@ -438,7 +436,7 @@ class CFMSTestClient:
         if self.multiplexer is None:
             raise RuntimeError("Not connected to server. Call connect() first.")
 
-        stream = self.multiplexer.create_stream()
+        stream = self.multiplexer.open_stream()
         await stream.send(orjson.dumps(request))
 
         frame = await stream.recv()
@@ -852,7 +850,7 @@ class CFMSTestClient:
         if self.multiplexer is None:
             raise RuntimeError("Not connected (multiplexing missing).")
 
-        stream = self.multiplexer.create_stream()
+        stream = self.multiplexer.open_stream()
         frame = await self._build_and_send_request(
             stream,
             "download_file",
@@ -932,7 +930,7 @@ class CFMSTestClient:
         if self.multiplexer is None:
             raise RuntimeError("Not connected (multiplexing missing).")
 
-        stream = self.multiplexer.create_stream()
+        stream = self.multiplexer.open_stream()
         frame = await self._build_and_send_request(
             stream,
             "upload_file",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -18,7 +18,9 @@ from typing import Any, Dict, Optional
 
 import orjson
 from Crypto.Cipher import AES
+from loguru import logger as log
 from websockets.asyncio.client import ClientConnection, connect
+from websockets.typing import DataLike
 
 from include.transport.multiplexing import (
     Frame,
@@ -26,6 +28,8 @@ from include.transport.multiplexing import (
     decode_frame,
     encode_frame,
 )
+
+logger = log.bind(name="test_client.multiplexer")
 
 
 def calculate_sha256(file_path: str) -> str:
@@ -52,7 +56,9 @@ class AsyncStream:
         self.frame_id = frame_id
         self._queue: queue.Queue = queue.Queue(100)
 
-    async def send(self, data: Any, frame_type: FrameType = FrameType.DATA):
+    async def send(
+        self, data: DataLike, frame_type: FrameType = FrameType.DATA
+    ) -> None:
         await self.connection._send_frame(self.frame_id, frame_type, data)
 
     async def recv(self, timeout: Optional[float] = None) -> Frame:
@@ -104,7 +110,7 @@ class AsyncMultiplexConnection:
         except queue.Empty:
             raise TimeoutError("Server stream accept timeout")
 
-    async def _recv_loop(self):
+    async def _recv_loop(self) -> None:
         try:
             while self._is_running:
                 raw_payload = await self._ws.recv(decode=False)
@@ -131,7 +137,7 @@ class AsyncMultiplexConnection:
                         self._streams.pop(frame.stream_id, None)
 
         except Exception:
-            pass
+            logger.exception("Error in async multiplex receive loop")
         finally:
             self._is_running = False
             self._new_streams.put(None)
@@ -139,7 +145,9 @@ class AsyncMultiplexConnection:
                 for stream in self._streams.values():
                     stream._put_incoming_frame(None)
 
-    async def _send_frame(self, frame_id: int, frame_type: FrameType, data: Any):
+    async def _send_frame(
+        self, frame_id: int, frame_type: FrameType, data: DataLike
+    ) -> None:
         await self._ws.send(encode_frame(frame_id, frame_type, data))
 
         if frame_type == FrameType.CONCLUSION:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,20 +12,20 @@ import os
 import queue
 import secrets
 import ssl
-import struct
 import threading
 import time
-from dataclasses import dataclass
-from enum import IntEnum
 from typing import Any, Dict, Optional
 
 import orjson
 from Crypto.Cipher import AES
 from websockets.asyncio.client import ClientConnection, connect
 
-FRAME_HEADER_FORMAT = "!IB"
-FRAME_HEADER = struct.Struct(FRAME_HEADER_FORMAT)
-FRAME_HEADER_SIZE = FRAME_HEADER.size
+from include.transport.multiplexing import (
+    Frame,
+    FrameType,
+    decode_frame,
+    encode_frame,
+)
 
 
 def calculate_sha256(file_path: str) -> str:
@@ -46,18 +46,6 @@ def calculate_sha256(file_path: str) -> str:
         return hashlib.sha256(mmapped_file).hexdigest()
 
 
-class FrameType(IntEnum):
-    DATA = 0
-    CONCLUSION = 1
-
-
-@dataclass
-class Frame:
-    stream_id: int
-    frame_type: FrameType
-    data: Any
-
-
 class AsyncStream:
     def __init__(self, connection: "AsyncMultiplexConnection", frame_id: int):
         self.connection = connection
@@ -70,13 +58,9 @@ class AsyncStream:
     async def recv(self, timeout: Optional[float] = None) -> Frame:
         try:
             if timeout is None:
-                frame = await asyncio.get_running_loop().run_in_executor(
-                    None, self._queue.get
-                )
+                frame = await asyncio.to_thread(self._queue.get)
             else:
-                frame = await asyncio.get_running_loop().run_in_executor(
-                    None, lambda: self._queue.get(timeout=timeout)
-                )
+                frame = await asyncio.to_thread(self._queue.get, True, timeout)
         except queue.Empty:
             raise TimeoutError("Stream recv timeout")
 
@@ -115,46 +99,28 @@ class AsyncMultiplexConnection:
     ) -> Optional[AsyncStream]:
         try:
             if timeout is None:
-                return await asyncio.get_running_loop().run_in_executor(
-                    None, self._new_streams.get
-                )
-            return await asyncio.get_running_loop().run_in_executor(
-                None, lambda: self._new_streams.get(timeout=timeout)
-            )
+                return await asyncio.to_thread(self._new_streams.get)
+            return await asyncio.to_thread(self._new_streams.get, True, timeout)
         except queue.Empty:
             raise TimeoutError("Server stream accept timeout")
 
     async def _recv_loop(self):
         try:
             while self._is_running:
-                raw_payload = await self._ws.recv()
-                if isinstance(raw_payload, str):
-                    raw_payload = raw_payload.encode("utf-8")
-
-                if len(raw_payload) < FRAME_HEADER_SIZE:
+                raw_payload = await self._ws.recv(decode=False)
+                frame = decode_frame(raw_payload)
+                if frame is None:
                     continue
-
-                stream_id, frame_type_val = FRAME_HEADER.unpack_from(raw_payload)
-                data_bytes = raw_payload[FRAME_HEADER_SIZE:]
-
-                try:
-                    frame_type = FrameType(frame_type_val)
-                except ValueError:
-                    continue
-
-                frame = Frame(
-                    stream_id=stream_id, frame_type=frame_type, data=data_bytes
-                )
 
                 with self._streams_lock:
-                    target_stream = self._streams.get(stream_id)
+                    target_stream = self._streams.get(frame.stream_id)
                     if target_stream is None:
-                        if stream_id % 2 != 0:
+                        if frame.stream_id % 2 != 0:
                             self._is_running = False
                             await self._ws.close()
                             return
-                        new_stream = AsyncStream(self, stream_id)
-                        self._streams[stream_id] = new_stream
+                        new_stream = AsyncStream(self, frame.stream_id)
+                        self._streams[frame.stream_id] = new_stream
                         self._new_streams.put(new_stream)
                         target_stream = new_stream
 
@@ -162,7 +128,7 @@ class AsyncMultiplexConnection:
 
                 if frame.frame_type == FrameType.CONCLUSION:
                     with self._streams_lock:
-                        self._streams.pop(stream_id, None)
+                        self._streams.pop(frame.stream_id, None)
 
         except Exception:
             pass
@@ -174,19 +140,7 @@ class AsyncMultiplexConnection:
                     stream._put_incoming_frame(None)
 
     async def _send_frame(self, frame_id: int, frame_type: FrameType, data: Any):
-        if isinstance(data, str):
-            data = data.encode("utf-8")
-        elif isinstance(data, memoryview):
-            data = data.tobytes()
-
-        if not isinstance(data, (bytes, bytearray, memoryview)):
-            raise TypeError("Frame data must be str, bytes, bytearray, or memoryview")
-
-        payload = bytearray(FRAME_HEADER_SIZE + len(data))
-        FRAME_HEADER.pack_into(payload, 0, frame_id, frame_type.value)
-        payload[FRAME_HEADER_SIZE:] = data
-
-        await self._ws.send(payload)
+        await self._ws.send(encode_frame(frame_id, frame_type, data))
 
         if frame_type == FrameType.CONCLUSION:
             with self._streams_lock:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -57,7 +57,7 @@ class AsyncStream:
         self._queue: queue.Queue = queue.Queue(100)
 
     async def send(
-        self, data: DataLike, frame_type: FrameType = FrameType.DATA
+        self, data: DataLike, frame_type: FrameType = FrameType.PROCESS
     ) -> None:
         await self.connection._send_frame(self.frame_id, frame_type, data)
 

--- a/tests/test_file_transfer.py
+++ b/tests/test_file_transfer.py
@@ -341,7 +341,7 @@ class TestFileTransfer:
 
         fake_stream = FakeStream()
         monkeypatch.setattr(
-            authenticated_client.multiplexer, "create_stream", lambda: fake_stream
+            authenticated_client.multiplexer, "open_stream", lambda: fake_stream
         )
 
         dest = tmp_path / "aborted.bin"

--- a/tests/test_multiplexing.py
+++ b/tests/test_multiplexing.py
@@ -331,6 +331,19 @@ def test_invalid_inbound_frame_closes_connection_with_protocol_error():
         connection.close()
 
 
+def test_open_stream_raises_after_receive_loop_closes_connection():
+    websocket = _InvalidFrameWebSocket()
+    connection = MultiplexedConnection(websocket)
+
+    try:
+        assert websocket.closed.wait(timeout=1)
+
+        with pytest.raises(ConnectionClosedError):
+            connection.open_stream()
+    finally:
+        connection.close()
+
+
 def test_close_unblocks_send_waiting_for_outbound_queue_space(monkeypatch):
     outbound_put_blocked = threading.Event()
 
@@ -519,6 +532,33 @@ def test_broadcast_logs_diagnostics_when_dropping_slow_client(monkeypatch):
             "remote_address=('127.0.0.1', 12345), "
             f"outbound_queue_size={OUTBOUND_QUEUE_SIZE}"
         ]
+    finally:
+        with clients_lock:
+            clients.discard(connection)
+        connection.close()
+
+
+def test_broadcast_ignores_already_closed_connections(monkeypatch):
+    websocket = _SyncWebSocket()
+    connection = MultiplexedConnection(websocket)
+    messages = []
+
+    class _Logger:
+        def warning(self, message):
+            messages.append(message)
+
+        def exception(self, message):
+            messages.append(message)
+
+    try:
+        monkeypatch.setattr(broadcast_module, "logger", _Logger())
+        connection.close()
+        with clients_lock:
+            clients.add(connection)
+
+        on_global_broadcast("hello")
+
+        assert messages == []
     finally:
         with clients_lock:
             clients.discard(connection)

--- a/tests/test_multiplexing.py
+++ b/tests/test_multiplexing.py
@@ -1,4 +1,5 @@
 import asyncio
+import queue
 import threading
 import time
 
@@ -7,6 +8,7 @@ import pytest
 from include.domains.operations import broadcast as broadcast_module
 from include.domains.operations.broadcast import on_global_broadcast
 from include.shared import clients, clients_lock
+from include.transport import multiplexing as multiplexing_module
 from include.transport.multiplexing import (
     FRAME_HEADER,
     FRAME_HEADER_SIZE,
@@ -18,6 +20,8 @@ from include.transport.multiplexing import (
     encode_frame,
 )
 from tests.test_client import AsyncMultiplexConnection
+
+_ORIGINAL_QUEUE = queue.Queue
 
 
 class _IdleWebSocket:
@@ -89,6 +93,18 @@ class _SyncWebSocket:
     def close(self, *args, **kwargs):
         self.release_send.set()
         self.closed.set()
+
+
+class _BlockingPutSignalingQueue(_ORIGINAL_QUEUE):
+    def __init__(self, maxsize: int, put_blocked: threading.Event) -> None:
+        super().__init__(maxsize)
+        self.put_blocked = put_blocked
+
+    def put(self, item, block=True, timeout=None):
+        with self.mutex:
+            if block and self.maxsize > 0 and self._qsize() >= self.maxsize:
+                self.put_blocked.set()
+        return super().put(item, block=block, timeout=timeout)
 
 
 def test_stream_send_waits_until_writer_sends():
@@ -236,7 +252,16 @@ def test_stream_send_nowait_returns_false_after_connection_close():
     assert websocket.sent == []
 
 
-def test_close_unblocks_send_waiting_for_outbound_queue_space():
+def test_close_unblocks_send_waiting_for_outbound_queue_space(monkeypatch):
+    outbound_put_blocked = threading.Event()
+
+    def queue_factory(maxsize=0):
+        if maxsize == OUTBOUND_QUEUE_SIZE:
+            return _BlockingPutSignalingQueue(maxsize, outbound_put_blocked)
+        return _ORIGINAL_QUEUE(maxsize)
+
+    monkeypatch.setattr(multiplexing_module.queue, "Queue", queue_factory)
+
     websocket = _SyncWebSocket(block_send=True)
     connection = MultiplexedConnection(websocket)
     done = threading.Event()
@@ -259,7 +284,7 @@ def test_close_unblocks_send_waiting_for_outbound_queue_space():
 
         sender = threading.Thread(target=send_when_queue_is_full)
         sender.start()
-        time.sleep(0.1)
+        assert outbound_put_blocked.wait(timeout=1)
 
         connection.close()
 

--- a/tests/test_multiplexing.py
+++ b/tests/test_multiplexing.py
@@ -8,11 +8,13 @@ from include.domains.operations import broadcast as broadcast_module
 from include.domains.operations.broadcast import on_global_broadcast
 from include.shared import clients, clients_lock
 from include.transport.multiplexing import (
-    HEADER,
-    HEADER_SIZE,
+    FRAME_HEADER,
+    FRAME_HEADER_SIZE,
     OUTBOUND_QUEUE_SIZE,
+    Frame,
     FrameType,
-    MultiplexConnection,
+    MultiplexedConnection,
+    Stream,
 )
 from tests.test_client import AsyncMultiplexConnection
 
@@ -39,9 +41,9 @@ async def test_test_client_uses_odd_client_stream_ids():
     connection = AsyncMultiplexConnection(websocket)
 
     try:
-        first = connection.create_stream()
-        second = connection.create_stream()
-        third = connection.create_stream()
+        first = connection.open_stream()
+        second = connection.open_stream()
+        third = connection.open_stream()
 
         assert first.frame_id == 1
         assert second.frame_id == 3
@@ -90,12 +92,12 @@ class _SyncWebSocket:
 
 def test_stream_send_waits_until_writer_sends():
     websocket = _SyncWebSocket(block_send=True)
-    connection = MultiplexConnection(websocket)
-    stream = connection.create_stream()
+    connection = MultiplexedConnection(websocket)
+    stream = connection.open_stream()
     done = threading.Event()
 
     sender = threading.Thread(
-        target=lambda: (stream.send(b"payload", FrameType.PROCESS), done.set())
+        target=lambda: (stream.send(b"payload", FrameType.DATA), done.set())
     )
     sender.start()
 
@@ -113,11 +115,11 @@ def test_stream_send_waits_until_writer_sends():
 
 def test_stream_send_nowait_does_not_wait_for_socket_io():
     websocket = _SyncWebSocket(block_send=True)
-    connection = MultiplexConnection(websocket)
-    stream = connection.create_stream()
+    connection = MultiplexedConnection(websocket)
+    stream = connection.open_stream()
 
     try:
-        assert stream.send_nowait(b"payload", FrameType.PROCESS) is True
+        assert stream.send_nowait(b"payload", FrameType.DATA) is True
         assert websocket.send_entered.wait(timeout=1)
         assert websocket.sent == []
 
@@ -132,24 +134,24 @@ def test_stream_send_nowait_does_not_wait_for_socket_io():
 
 def test_stream_send_nowait_returns_false_when_queue_is_full():
     websocket = _SyncWebSocket(block_send=True)
-    connection = MultiplexConnection(websocket)
+    connection = MultiplexedConnection(websocket)
 
     try:
-        assert connection.create_stream().send_nowait(b"blocked") is True
+        assert connection.open_stream().send_nowait(b"blocked") is True
         assert websocket.send_entered.wait(timeout=1)
 
         for _ in range(OUTBOUND_QUEUE_SIZE):
-            assert connection.create_stream().send_nowait(b"queued") is True
+            assert connection.open_stream().send_nowait(b"queued") is True
 
-        assert connection.create_stream().send_nowait(b"overflow") is False
+        assert connection.open_stream().send_nowait(b"overflow") is False
     finally:
         connection.close()
 
 
 def test_stream_send_nowait_conclusion_removes_stream_when_queued():
     websocket = _SyncWebSocket(block_send=True)
-    connection = MultiplexConnection(websocket)
-    stream = connection.create_stream()
+    connection = MultiplexedConnection(websocket)
+    stream = connection.open_stream()
 
     try:
         assert stream.frame_id in connection._streams
@@ -161,16 +163,16 @@ def test_stream_send_nowait_conclusion_removes_stream_when_queued():
 
 def test_stream_send_nowait_conclusion_keeps_stream_when_queue_is_full():
     websocket = _SyncWebSocket(block_send=True)
-    connection = MultiplexConnection(websocket)
+    connection = MultiplexedConnection(websocket)
 
     try:
-        assert connection.create_stream().send_nowait(b"blocked") is True
+        assert connection.open_stream().send_nowait(b"blocked") is True
         assert websocket.send_entered.wait(timeout=1)
 
         for _ in range(OUTBOUND_QUEUE_SIZE):
-            assert connection.create_stream().send_nowait(b"queued") is True
+            assert connection.open_stream().send_nowait(b"queued") is True
 
-        stream = connection.create_stream()
+        stream = connection.open_stream()
         assert stream.send_nowait(b"overflow", FrameType.CONCLUSION) is False
         assert stream.frame_id in connection._streams
     finally:
@@ -187,34 +189,76 @@ def test_stream_send_nowait_conclusion_keeps_stream_when_queue_is_full():
     ],
 )
 def test_encode_frame_accepts_supported_payload_types(data, expected):
-    connection = MultiplexConnection.__new__(MultiplexConnection)
+    connection = MultiplexedConnection.__new__(MultiplexedConnection)
 
-    payload = connection._encode_frame(2, FrameType.PROCESS, data)
+    payload = connection._encode_frame(2, FrameType.DATA, data)
 
-    assert HEADER.unpack_from(payload) == (2, FrameType.PROCESS.value)
-    assert payload[HEADER_SIZE:] == expected
+    assert FRAME_HEADER.unpack_from(payload) == (2, FrameType.DATA.value)
+    assert payload[FRAME_HEADER_SIZE:] == expected
+
+
+def test_frame_uses_stream_id_field():
+    frame = Frame(stream_id=3, frame_type=FrameType.DATA, data=b"payload")
+
+    assert frame.stream_id == 3
+
+
+def test_encode_frame_rejects_unsupported_payload_type():
+    connection = MultiplexedConnection.__new__(MultiplexedConnection)
+
+    with pytest.raises(TypeError, match="Frame data must be"):
+        connection._encode_frame(2, FrameType.DATA, None)
+
+
+def test_stream_recv_timeout_raises_timeout_error():
+    connection = MultiplexedConnection.__new__(MultiplexedConnection)
+    stream = Stream(connection, 2)
+
+    with pytest.raises(TimeoutError):
+        stream.recv(timeout=0.01)
+
+
+def test_open_stream_raises_after_connection_close():
+    websocket = _SyncWebSocket()
+    connection = MultiplexedConnection(websocket)
+
+    connection.close()
+
+    with pytest.raises(ConnectionError):
+        connection.open_stream()
+
+
+def test_stream_send_nowait_returns_false_after_connection_close():
+    websocket = _SyncWebSocket()
+    connection = MultiplexedConnection(websocket)
+    stream = connection.open_stream()
+
+    connection.close()
+
+    assert stream.send_nowait(b"payload", FrameType.DATA) is False
+    assert websocket.sent == []
 
 
 def test_close_unblocks_send_waiting_for_outbound_queue_space():
     websocket = _SyncWebSocket(block_send=True)
-    connection = MultiplexConnection(websocket)
+    connection = MultiplexedConnection(websocket)
     done = threading.Event()
     errors = []
 
     def send_when_queue_is_full():
         try:
-            connection.create_stream().send(b"blocked-on-queue", FrameType.PROCESS)
+            connection.open_stream().send(b"blocked-on-queue", FrameType.DATA)
         except Exception as exc:
             errors.append(exc)
         finally:
             done.set()
 
     try:
-        assert connection.create_stream().send_nowait(b"blocked") is True
+        assert connection.open_stream().send_nowait(b"blocked") is True
         assert websocket.send_entered.wait(timeout=1)
 
         for _ in range(OUTBOUND_QUEUE_SIZE):
-            assert connection.create_stream().send_nowait(b"queued") is True
+            assert connection.open_stream().send_nowait(b"queued") is True
 
         sender = threading.Thread(target=send_when_queue_is_full)
         sender.start()
@@ -233,12 +277,12 @@ def test_close_unblocks_send_waiting_for_outbound_queue_space():
 
 def test_stream_send_raises_when_writer_fails():
     websocket = _SyncWebSocket(send_error=OSError("boom"))
-    connection = MultiplexConnection(websocket)
-    stream = connection.create_stream()
+    connection = MultiplexedConnection(websocket)
+    stream = connection.open_stream()
 
     try:
         with pytest.raises(ConnectionError):
-            stream.send(b"payload", FrameType.PROCESS)
+            stream.send(b"payload", FrameType.DATA)
     finally:
         connection.close()
 
@@ -246,13 +290,13 @@ def test_stream_send_raises_when_writer_fails():
 def test_pending_stream_sends_preserve_writer_failure_cause():
     send_error = OSError("boom")
     websocket = _SyncWebSocket(block_send=True, send_error=send_error)
-    connection = MultiplexConnection(websocket)
+    connection = MultiplexedConnection(websocket)
     errors = []
 
     def send_and_capture(index: int):
         try:
-            stream = connection.create_stream()
-            stream.send(f"payload-{index}".encode(), FrameType.PROCESS)
+            stream = connection.open_stream()
+            stream.send(f"payload-{index}".encode(), FrameType.DATA)
         except Exception as exc:
             errors.append(exc)
 
@@ -291,15 +335,15 @@ def test_pending_stream_sends_preserve_writer_failure_cause():
 
 def test_concurrent_stream_sends_are_serialized_by_writer():
     websocket = _SyncWebSocket()
-    connection = MultiplexConnection(websocket)
+    connection = MultiplexedConnection(websocket)
     barrier = threading.Barrier(6)
     errors = []
 
     def send_from_thread(index: int):
         try:
-            stream = connection.create_stream()
+            stream = connection.open_stream()
             barrier.wait(timeout=1)
-            stream.send(f"payload-{index}".encode(), FrameType.PROCESS)
+            stream.send(f"payload-{index}".encode(), FrameType.DATA)
         except Exception as exc:
             errors.append(exc)
 
@@ -324,7 +368,7 @@ def test_concurrent_stream_sends_are_serialized_by_writer():
 
 def test_broadcast_does_not_wait_for_slow_client():
     websocket = _SyncWebSocket(block_send=True)
-    connection = MultiplexConnection(websocket)
+    connection = MultiplexedConnection(websocket)
     done = threading.Event()
 
     with clients_lock:
@@ -348,7 +392,7 @@ def test_broadcast_does_not_wait_for_slow_client():
 
 def test_broadcast_logs_diagnostics_when_dropping_slow_client(monkeypatch):
     websocket = _SyncWebSocket(block_send=True)
-    connection = MultiplexConnection(websocket)
+    connection = MultiplexedConnection(websocket)
     warnings = []
 
     class _Logger:
@@ -358,11 +402,11 @@ def test_broadcast_logs_diagnostics_when_dropping_slow_client(monkeypatch):
     monkeypatch.setattr(broadcast_module, "logger", _Logger())
 
     try:
-        assert connection.create_stream().send_nowait(b"blocked") is True
+        assert connection.open_stream().send_nowait(b"blocked") is True
         assert websocket.send_entered.wait(timeout=1)
 
         for _ in range(OUTBOUND_QUEUE_SIZE):
-            assert connection.create_stream().send_nowait(b"queued") is True
+            assert connection.open_stream().send_nowait(b"queued") is True
 
         with clients_lock:
             clients.add(connection)

--- a/tests/test_multiplexing.py
+++ b/tests/test_multiplexing.py
@@ -15,6 +15,7 @@ from include.transport.multiplexing import (
     FrameType,
     MultiplexedConnection,
     Stream,
+    encode_frame,
 )
 from tests.test_client import AsyncMultiplexConnection
 
@@ -24,7 +25,7 @@ class _IdleWebSocket:
         self.sent = []
         self._closed = asyncio.Event()
 
-    async def recv(self):
+    async def recv(self, decode=None):
         await self._closed.wait()
         return b""
 
@@ -73,7 +74,7 @@ class _SyncWebSocket:
         self.block_send = block_send
         self.send_error = send_error
 
-    def recv(self):
+    def recv(self, timeout=None, decode=None):
         self.closed.wait()
         raise RuntimeError("closed")
 
@@ -189,9 +190,7 @@ def test_stream_send_nowait_conclusion_keeps_stream_when_queue_is_full():
     ],
 )
 def test_encode_frame_accepts_supported_payload_types(data, expected):
-    connection = MultiplexedConnection.__new__(MultiplexedConnection)
-
-    payload = connection._encode_frame(2, FrameType.DATA, data)
+    payload = encode_frame(2, FrameType.DATA, data)
 
     assert FRAME_HEADER.unpack_from(payload) == (2, FrameType.DATA.value)
     assert payload[FRAME_HEADER_SIZE:] == expected
@@ -204,10 +203,8 @@ def test_frame_uses_stream_id_field():
 
 
 def test_encode_frame_rejects_unsupported_payload_type():
-    connection = MultiplexedConnection.__new__(MultiplexedConnection)
-
     with pytest.raises(TypeError, match="Frame data must be"):
-        connection._encode_frame(2, FrameType.DATA, None)
+        encode_frame(2, FrameType.DATA, None)
 
 
 def test_stream_recv_timeout_raises_timeout_error():

--- a/tests/test_multiplexing.py
+++ b/tests/test_multiplexing.py
@@ -114,7 +114,7 @@ def test_stream_send_waits_until_writer_sends():
     done = threading.Event()
 
     sender = threading.Thread(
-        target=lambda: (stream.send(b"payload", FrameType.DATA), done.set())
+        target=lambda: (stream.send(b"payload", FrameType.PROCESS), done.set())
     )
     sender.start()
 
@@ -136,7 +136,7 @@ def test_stream_send_nowait_does_not_wait_for_socket_io():
     stream = connection.open_stream()
 
     try:
-        assert stream.send_nowait(b"payload", FrameType.DATA) is True
+        assert stream.send_nowait(b"payload", FrameType.PROCESS) is True
         assert websocket.send_entered.wait(timeout=1)
         assert websocket.sent == []
 
@@ -206,21 +206,21 @@ def test_stream_send_nowait_conclusion_keeps_stream_when_queue_is_full():
     ],
 )
 def test_encode_frame_accepts_supported_payload_types(data, expected):
-    payload = encode_frame(2, FrameType.DATA, data)
+    payload = encode_frame(2, FrameType.PROCESS, data)
 
-    assert FRAME_HEADER.unpack_from(payload) == (2, FrameType.DATA.value)
+    assert FRAME_HEADER.unpack_from(payload) == (2, FrameType.PROCESS.value)
     assert payload[FRAME_HEADER_SIZE:] == expected
 
 
 def test_frame_uses_stream_id_field():
-    frame = Frame(stream_id=3, frame_type=FrameType.DATA, data=b"payload")
+    frame = Frame(stream_id=3, frame_type=FrameType.PROCESS, data=b"payload")
 
     assert frame.stream_id == 3
 
 
 def test_encode_frame_rejects_unsupported_payload_type():
     with pytest.raises(TypeError, match="Frame data must be"):
-        encode_frame(2, FrameType.DATA, None)
+        encode_frame(2, FrameType.PROCESS, None)
 
 
 def test_stream_recv_timeout_raises_timeout_error():
@@ -248,7 +248,7 @@ def test_stream_send_nowait_returns_false_after_connection_close():
 
     connection.close()
 
-    assert stream.send_nowait(b"payload", FrameType.DATA) is False
+    assert stream.send_nowait(b"payload", FrameType.PROCESS) is False
     assert websocket.sent == []
 
 
@@ -269,7 +269,7 @@ def test_close_unblocks_send_waiting_for_outbound_queue_space(monkeypatch):
 
     def send_when_queue_is_full():
         try:
-            connection.open_stream().send(b"blocked-on-queue", FrameType.DATA)
+            connection.open_stream().send(b"blocked-on-queue", FrameType.PROCESS)
         except Exception as exc:
             errors.append(exc)
         finally:
@@ -304,7 +304,7 @@ def test_stream_send_raises_when_writer_fails():
 
     try:
         with pytest.raises(ConnectionError):
-            stream.send(b"payload", FrameType.DATA)
+            stream.send(b"payload", FrameType.PROCESS)
     finally:
         connection.close()
 
@@ -318,7 +318,7 @@ def test_pending_stream_sends_preserve_writer_failure_cause():
     def send_and_capture(index: int):
         try:
             stream = connection.open_stream()
-            stream.send(f"payload-{index}".encode(), FrameType.DATA)
+            stream.send(f"payload-{index}".encode(), FrameType.PROCESS)
         except Exception as exc:
             errors.append(exc)
 
@@ -334,12 +334,12 @@ def test_pending_stream_sends_preserve_writer_failure_cause():
             thread.start()
 
         deadline = time.monotonic() + 1
-        while connection._outbound.qsize() < len(threads) - 1:
+        while connection._pending_outbound_frames.qsize() < len(threads) - 1:
             if time.monotonic() >= deadline:
                 break
             time.sleep(0.01)
 
-        assert connection._outbound.qsize() == len(threads) - 1
+        assert connection._pending_outbound_frames.qsize() == len(threads) - 1
         websocket.release_send.set()
 
         for thread in threads:
@@ -365,7 +365,7 @@ def test_concurrent_stream_sends_are_serialized_by_writer():
         try:
             stream = connection.open_stream()
             barrier.wait(timeout=1)
-            stream.send(f"payload-{index}".encode(), FrameType.DATA)
+            stream.send(f"payload-{index}".encode(), FrameType.PROCESS)
         except Exception as exc:
             errors.append(exc)
 

--- a/tests/test_multiplexing.py
+++ b/tests/test_multiplexing.py
@@ -8,6 +8,8 @@ from include.domains.operations import broadcast as broadcast_module
 from include.domains.operations.broadcast import on_global_broadcast
 from include.shared import clients, clients_lock
 from include.transport.multiplexing import (
+    HEADER,
+    HEADER_SIZE,
     OUTBOUND_QUEUE_SIZE,
     FrameType,
     MultiplexConnection,
@@ -172,6 +174,60 @@ def test_stream_send_nowait_conclusion_keeps_stream_when_queue_is_full():
         assert stream.send_nowait(b"overflow", FrameType.CONCLUSION) is False
         assert stream.frame_id in connection._streams
     finally:
+        connection.close()
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        (b"payload", b"payload"),
+        ("payload", b"payload"),
+        (bytearray(b"payload"), b"payload"),
+        (memoryview(b"payload"), b"payload"),
+    ],
+)
+def test_encode_frame_accepts_supported_payload_types(data, expected):
+    connection = MultiplexConnection.__new__(MultiplexConnection)
+
+    payload = connection._encode_frame(2, FrameType.PROCESS, data)
+
+    assert HEADER.unpack_from(payload) == (2, FrameType.PROCESS.value)
+    assert payload[HEADER_SIZE:] == expected
+
+
+def test_close_unblocks_send_waiting_for_outbound_queue_space():
+    websocket = _SyncWebSocket(block_send=True)
+    connection = MultiplexConnection(websocket)
+    done = threading.Event()
+    errors = []
+
+    def send_when_queue_is_full():
+        try:
+            connection.create_stream().send(b"blocked-on-queue", FrameType.PROCESS)
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            done.set()
+
+    try:
+        assert connection.create_stream().send_nowait(b"blocked") is True
+        assert websocket.send_entered.wait(timeout=1)
+
+        for _ in range(OUTBOUND_QUEUE_SIZE):
+            assert connection.create_stream().send_nowait(b"queued") is True
+
+        sender = threading.Thread(target=send_when_queue_is_full)
+        sender.start()
+        time.sleep(0.1)
+
+        connection.close()
+
+        assert done.wait(timeout=1)
+        sender.join(timeout=1)
+        assert len(errors) == 1
+        assert isinstance(errors[0], ConnectionError)
+    finally:
+        websocket.release_send.set()
         connection.close()
 
 

--- a/tests/test_multiplexing.py
+++ b/tests/test_multiplexing.py
@@ -13,10 +13,15 @@ from include.transport.multiplexing import (
     FRAME_HEADER,
     FRAME_HEADER_SIZE,
     OUTBOUND_QUEUE_SIZE,
+    ConnectionClosedError,
+    CorruptedFrameError,
     Frame,
     FrameType,
+    InvalidFrameError,
+    InvalidFrameTypeError,
     MultiplexedConnection,
     Stream,
+    decode_frame,
     encode_frame,
 )
 from tests.test_client import AsyncMultiplexConnection
@@ -93,6 +98,21 @@ class _SyncWebSocket:
     def close(self, *args, **kwargs):
         self.release_send.set()
         self.closed.set()
+
+
+class _InvalidFrameWebSocket(_SyncWebSocket):
+    def __init__(self):
+        super().__init__()
+        self.close_args = None
+        self.close_kwargs = None
+
+    def recv(self, timeout=None, decode=None):
+        return b"bad"
+
+    def close(self, *args, **kwargs):
+        self.close_args = args
+        self.close_kwargs = kwargs
+        super().close(*args, **kwargs)
 
 
 class _BlockingPutSignalingQueue(_ORIGINAL_QUEUE):
@@ -223,6 +243,37 @@ def test_encode_frame_rejects_unsupported_payload_type():
         encode_frame(2, FrameType.PROCESS, None)
 
 
+def test_decode_frame_rejects_short_payload_with_structured_error():
+    with pytest.raises(CorruptedFrameError) as excinfo:
+        decode_frame(b"bad")
+
+    error = excinfo.value
+    assert isinstance(error, InvalidFrameError)
+    assert error.actual_size == 3
+    assert error.minimum_size == FRAME_HEADER_SIZE
+    assert error.close_code == 1002
+    assert error.close_reason == "Protocol error: invalid frame"
+    assert str(error) == (
+        f"Frame too short: 3 bytes, expected at least {FRAME_HEADER_SIZE} bytes"
+    )
+
+
+def test_decode_frame_rejects_unknown_frame_type_with_structured_error():
+    payload = bytearray(FRAME_HEADER_SIZE)
+    FRAME_HEADER.pack_into(payload, 0, 3, 99)
+
+    with pytest.raises(InvalidFrameTypeError) as excinfo:
+        decode_frame(payload)
+
+    error = excinfo.value
+    assert isinstance(error, InvalidFrameError)
+    assert error.stream_id == 3
+    assert error.frame_type_value == 99
+    assert error.valid_frame_type_values == (0, 1)
+    assert error.__cause__ is not None
+    assert str(error) == "Invalid frame type 99 for stream 3; expected one of 0, 1"
+
+
 def test_stream_recv_timeout_raises_timeout_error():
     connection = MultiplexedConnection.__new__(MultiplexedConnection)
     stream = Stream(connection, 2)
@@ -231,13 +282,26 @@ def test_stream_recv_timeout_raises_timeout_error():
         stream.recv(timeout=0.01)
 
 
+def test_stream_recv_closed_raises_connection_closed_error():
+    connection = MultiplexedConnection.__new__(MultiplexedConnection)
+    stream = Stream(connection, 2)
+    stream._put_incoming_frame(None)
+
+    with pytest.raises(ConnectionClosedError):
+        stream.recv(timeout=0.01)
+
+
+def test_connection_closed_error_has_default_message():
+    assert str(ConnectionClosedError()) == "Connection has been closed"
+
+
 def test_open_stream_raises_after_connection_close():
     websocket = _SyncWebSocket()
     connection = MultiplexedConnection(websocket)
 
     connection.close()
 
-    with pytest.raises(ConnectionError):
+    with pytest.raises(ConnectionClosedError):
         connection.open_stream()
 
 
@@ -250,6 +314,21 @@ def test_stream_send_nowait_returns_false_after_connection_close():
 
     assert stream.send_nowait(b"payload", FrameType.PROCESS) is False
     assert websocket.sent == []
+
+
+def test_invalid_inbound_frame_closes_connection_with_protocol_error():
+    websocket = _InvalidFrameWebSocket()
+    connection = MultiplexedConnection(websocket)
+
+    try:
+        assert websocket.closed.wait(timeout=1)
+        assert websocket.close_kwargs == {
+            "code": 1002,
+            "reason": "Protocol error: invalid frame",
+        }
+        assert connection.accept_stream() is None
+    finally:
+        connection.close()
 
 
 def test_close_unblocks_send_waiting_for_outbound_queue_space(monkeypatch):
@@ -291,7 +370,7 @@ def test_close_unblocks_send_waiting_for_outbound_queue_space(monkeypatch):
         assert done.wait(timeout=1)
         sender.join(timeout=1)
         assert len(errors) == 1
-        assert isinstance(errors[0], ConnectionError)
+        assert isinstance(errors[0], ConnectionClosedError)
     finally:
         websocket.release_send.set()
         connection.close()

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -98,10 +98,11 @@ class TestSystemManagement:
             with pytest.raises(ConnectionClosed) as excinfo:
                 await asyncio.wait_for(websocket.recv(), timeout=5)
 
-            assert excinfo.value.code == 1002
-            assert (
-                excinfo.value.reason
-                == "Protocol error: invalid client-initiated stream"
+            close_frame = excinfo.value.rcvd
+            assert close_frame is not None
+            assert close_frame.code == 1002
+            assert close_frame.reason == (
+                "Protocol error: invalid client-initiated stream"
             )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary by Sourcery

Refactor WebSocket multiplexing to share frame encoding/decoding between client and server, improve send/close semantics, and adopt the renamed MultiplexedConnection and updated frame/stream terminology across the codebase.

New Features:
- Introduce reusable frame normalize/encode/decode helpers that accept multiple payload types and are shared by sync and async multiplexing clients.

Bug Fixes:
- Ensure protocol violations for client-initiated even stream IDs result in a proper close frame that tests can assert on.
- Make stream receive operations raise explicit TimeoutError on queue timeouts.
- Prevent senders blocking indefinitely on a full outbound queue by checking writer state and unblocking on connection close.

Enhancements:
- Rename MultiplexConnection to MultiplexedConnection and update FrameType and frame_id terminology to clearer DATA/stream_id naming.
- Strengthen writer error propagation and connection closed handling with explicit send-state tracking and improved exception mapping.
- Tighten type usage and dataclass definitions (slots, type hints) in multiplexing primitives and tests for better performance and clarity.

Tests:
- Update unit and system tests to use the new MultiplexedConnection API, shared frame helpers, and revised error/timeout behavior, adding coverage for queue-full, close-unblock, and payload-type handling.