### PR TITLE
Add DirectoryNameLock model and enhance name conflict handling

### DIFF
--- a/src/alembic/versions/2edcba9e076a_directory_name_locks.py
+++ b/src/alembic/versions/2edcba9e076a_directory_name_locks.py
@@ -1,0 +1,35 @@
+"""directory name locks
+
+Revision ID: 2edcba9e076a
+Revises: e37338db17cc
+Create Date: 2026-07-03 19:27:28.237437
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '2edcba9e076a'
+down_revision: Union[str, Sequence[str], None] = 'e37338db17cc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "directory_name_locks",
+        sa.Column("parent_id", sa.VARCHAR(length=255), nullable=False),
+        sa.Column("name", sa.VARCHAR(length=255), nullable=False),
+        sa.PrimaryKeyConstraint(
+            "parent_id", "name", name=op.f("pk_directory_name_locks")
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("directory_name_locks")

--- a/src/include/database/models/__init__.py
+++ b/src/include/database/models/__init__.py
@@ -9,6 +9,7 @@ from include.database.models.access import (
 )
 from include.database.models.documents import (
     BaseObject,
+    DirectoryNameLock,
     Document,
     DocumentMetadata,
     DocumentMetadataTag,
@@ -47,6 +48,7 @@ __all__ = [
     "DocumentMetadataTag",
     "DocumentRevision",
     "DocumentRevisionStatus",
+    "DirectoryNameLock",
     "EntityStatus",
     "File",
     "FileTask",

--- a/src/include/database/models/documents.py
+++ b/src/include/database/models/documents.py
@@ -9,6 +9,7 @@ __all__ = [
     "DocumentMetadata",
     "DocumentMetadataTag",
     "Folder",
+    "DirectoryNameLock",
 ]
 
 import secrets
@@ -209,6 +210,12 @@ class Folder(BaseObject):  # Document folder.
             visited_ids.add(current.id)
             current = current.parent
         return False
+
+
+class DirectoryNameLock(Base):
+    __tablename__ = "directory_name_locks"
+    parent_id: Mapped[str] = mapped_column(VARCHAR(255), primary_key=True)
+    name: Mapped[str] = mapped_column(VARCHAR(255), primary_key=True)
 
 
 class Document(BaseObject):

--- a/src/include/domains/documents/commands/name_conflicts.py
+++ b/src/include/domains/documents/commands/name_conflicts.py
@@ -1,10 +1,15 @@
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from include.config.constants import ROOT_DIRECTORY_ID
 from include.config.settings import global_config
-from include.database.models.documents import Document, Folder
+from include.database.models.documents import DirectoryNameLock, Document, Folder
 from include.database.models.identity import User
 from include.messages import Messages as smsg
+
+
+def normalize_object_name(name: str) -> str:
+    return name.strip()
 
 
 def get_target_folder_and_check_write(
@@ -49,72 +54,22 @@ def handle_name_duplicate(
 
     if not folder_id:
         folder_id = ROOT_DIRECTORY_ID
+    title = normalize_object_name(title)
 
-    existing_doc = (
-        session.query(Document)
-        .with_for_update()
-        .filter_by(folder_id=folder_id, title=title)
-        .first()
-    )
     existing_folder = (
         session.query(Folder)
         .with_for_update()
         .filter_by(parent_id=folder_id, name=title)
         .first()
     )
+    existing_docs = (
+        session.query(Document)
+        .with_for_update()
+        .filter_by(folder_id=folder_id, title=title)
+        .all()
+    )
 
-    if existing_doc:
-        if existing_doc.active:
-            resp_id = (
-                existing_doc.id
-                if existing_doc.check_access_requirements(user, "read")
-                else None
-            )
-            payload = {"type": "document", "id": resp_id}
-            if resp_id is not None:
-                payload["duplicate_id"] = resp_id
-
-            return (
-                True,
-                409,
-                payload,
-                smsg.DOCUMENT_NAME_DUPLICATE,
-            )
-        else:
-            if existing_doc.check_access_requirements(user, "write"):
-                try:
-                    existing_doc.delete_all_revisions(do_commit=False)
-                except PermissionError:
-                    return (
-                        True,
-                        500,
-                        {},
-                        "Failed to delete revisions. Perhaps a file task is in progress?",
-                    )
-                session.delete(existing_doc)
-                # Let caller commit
-            else:
-                resp_id = (
-                    existing_doc.id
-                    if existing_doc.check_access_requirements(user, "read")
-                    else None
-                )
-                payload = {"type": "document", "id": resp_id}
-                if resp_id is not None:
-                    payload["duplicate_id"] = resp_id
-
-                return (
-                    True,
-                    409,
-                    payload,
-                    getattr(
-                        smsg,
-                        "DENIED_FOR_DOC_NAME_DUPLICATE",
-                        smsg.DOCUMENT_NAME_DUPLICATE,
-                    ),
-                )
-
-    elif existing_folder:
+    if existing_folder:
         resp_id = (
             existing_folder.id
             if existing_folder.check_access_requirements(user, "read")
@@ -131,4 +86,79 @@ def handle_name_duplicate(
             smsg.DIRECTORY_NAME_DUPLICATE,
         )
 
+    inactive_docs: list[Document] = []
+    for existing_doc in existing_docs:
+        if existing_doc.active:
+            resp_id = (
+                existing_doc.id
+                if existing_doc.check_access_requirements(user, "read")
+                else None
+            )
+            payload = {"type": "document", "id": resp_id}
+            if resp_id is not None:
+                payload["duplicate_id"] = resp_id
+
+            return (
+                True,
+                409,
+                payload,
+                smsg.DOCUMENT_NAME_DUPLICATE,
+            )
+        inactive_docs.append(existing_doc)
+
+    for existing_doc in inactive_docs:
+        if not existing_doc.check_access_requirements(user, "write"):
+            resp_id = (
+                existing_doc.id
+                if existing_doc.check_access_requirements(user, "read")
+                else None
+            )
+            payload = {"type": "document", "id": resp_id}
+            if resp_id is not None:
+                payload["duplicate_id"] = resp_id
+
+            return (
+                True,
+                409,
+                payload,
+                getattr(
+                    smsg,
+                    "DENIED_FOR_DOC_NAME_DUPLICATE",
+                    smsg.DOCUMENT_NAME_DUPLICATE,
+                ),
+            )
+
+    for existing_doc in inactive_docs:
+        try:
+            existing_doc.delete_all_revisions(do_commit=False)
+        except PermissionError:
+            return (
+                True,
+                500,
+                {},
+                "Failed to delete revisions. Perhaps a file task is in progress?",
+            )
+        session.delete(existing_doc)
+
+    return False, 0, {}, ""
+
+
+def acquire_name_write_lock(
+    session: Session, folder_id: str | None, title: str
+) -> tuple[bool, int, dict, str]:
+    if global_config["document"]["allow_name_duplicate"]:
+        return False, 0, {}, ""
+
+    if not folder_id:
+        folder_id = ROOT_DIRECTORY_ID
+    title = normalize_object_name(title)
+
+    lock = DirectoryNameLock(parent_id=folder_id, name=title)
+    session.add(lock)
+    try:
+        session.flush()
+    except IntegrityError:
+        session.rollback()
+        return True, 409, {}, smsg.DOCUMENT_OR_DIRECTORY_NAME_DUPLICATE
+    session.delete(lock)
     return False, 0, {}, ""

--- a/src/include/domains/documents/commands/name_conflicts.py
+++ b/src/include/domains/documents/commands/name_conflicts.py
@@ -6,7 +6,12 @@ from sqlalchemy.orm import Session
 
 from include.config.constants import ROOT_DIRECTORY_ID
 from include.config.settings import global_config
-from include.database.models.documents import DirectoryNameLock, Document, Folder
+from include.database.models.documents import (
+    DirectoryNameLock,
+    Document,
+    EntityStatus,
+    Folder,
+)
 from include.database.models.identity import User
 from include.messages import Messages as smsg
 
@@ -23,6 +28,15 @@ class NameConflict:
 
 def normalize_object_name(name: str) -> str:
     return name.strip()
+
+
+def require_object_name(
+    name: str, required_message: str
+) -> tuple[str, NameConflict | None]:
+    normalized_name = normalize_object_name(name)
+    if not normalized_name:
+        return normalized_name, NameConflict(code=400, message=required_message)
+    return normalized_name, None
 
 
 def normalize_parent_id(folder_id: str | None) -> str:
@@ -91,13 +105,13 @@ def find_name_conflict(
     existing_folder = (
         session.query(Folder)
         .with_for_update()
-        .filter_by(parent_id=folder_id, name=title)
+        .filter_by(parent_id=folder_id, name=title, status=EntityStatus.OK)
         .first()
     )
     existing_docs = (
         session.query(Document)
         .with_for_update()
-        .filter_by(folder_id=folder_id, title=title)
+        .filter_by(folder_id=folder_id, title=title, status=EntityStatus.OK)
         .all()
     )
 

--- a/src/include/domains/documents/commands/name_conflicts.py
+++ b/src/include/domains/documents/commands/name_conflicts.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass, field
+from typing import Any
+
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -8,8 +11,22 @@ from include.database.models.identity import User
 from include.messages import Messages as smsg
 
 
+@dataclass(slots=True)
+class NameConflict:
+    code: int
+    message: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def public_data(self) -> dict[str, Any]:
+        return {key: value for key, value in self.data.items() if key != "entity"}
+
+
 def normalize_object_name(name: str) -> str:
     return name.strip()
+
+
+def normalize_parent_id(folder_id: str | None) -> str:
+    return folder_id or ROOT_DIRECTORY_ID
 
 
 def get_target_folder_and_check_write(
@@ -20,8 +37,7 @@ def get_target_folder_and_check_write(
     Returns (folder_object, error_code, error_message).
     If valid, error_code is 0.
     """
-    if not target_folder_id:
-        target_folder_id = ROOT_DIRECTORY_ID
+    target_folder_id = normalize_parent_id(target_folder_id)
 
     target_folder = (
         session.query(Folder).with_for_update().filter_by(id=target_folder_id).first()
@@ -40,20 +56,36 @@ def get_target_folder_and_check_write(
     return target_folder, 0, ""
 
 
-def handle_name_duplicate(
+def _duplicate_payload(
+    entity: Document | Folder,
+    user: User,
+    entity_type: str,
+    *,
+    include_entity: bool = False,
+) -> dict[str, Any]:
+    readable_id = entity.id if entity.check_access_requirements(user, "read") else None
+    payload: dict[str, Any] = {"type": entity_type, "id": readable_id}
+    if readable_id is not None:
+        payload["duplicate_id"] = readable_id
+    if include_entity:
+        payload["entity"] = entity
+    return payload
+
+
+def find_name_conflict(
     session: Session, user: User, folder_id: str | None, title: str
-) -> tuple[bool, int, dict, str]:
+) -> NameConflict | None:
     """
     Checks if a document or folder with `title` exists under `folder_id`.
     If yes, safely deletes deleted documents or returns conflict details.
-    Returns: (has_conflict, error_code, error_data, error_message).
-    If no conflict, returns (False, 0, {}, "").
+    Returns a conflict when a live sibling folder/document already owns the name.
+    Inactive documents are removed when the caller can write them, otherwise they
+    still block reuse to avoid hiding objects the caller cannot safely replace.
     """
     if global_config["document"]["allow_name_duplicate"]:
-        return False, 0, {}, ""
+        return None
 
-    if not folder_id:
-        folder_id = ROOT_DIRECTORY_ID
+    folder_id = normalize_parent_id(folder_id)
     title = normalize_object_name(title)
 
     existing_folder = (
@@ -70,87 +102,77 @@ def handle_name_duplicate(
     )
 
     if existing_folder:
-        resp_id = (
-            existing_folder.id
-            if existing_folder.check_access_requirements(user, "read")
-            else None
-        )
-        payload = {"type": "directory", "id": resp_id, "entity": existing_folder}
-        if resp_id is not None:
-            payload["duplicate_id"] = resp_id
-
-        return (
-            True,
-            409,
-            payload,
-            smsg.DIRECTORY_NAME_DUPLICATE,
+        return NameConflict(
+            code=409,
+            message=smsg.DIRECTORY_NAME_DUPLICATE,
+            data=_duplicate_payload(
+                existing_folder, user, "directory", include_entity=True
+            ),
         )
 
     inactive_docs: list[Document] = []
     for existing_doc in existing_docs:
         if existing_doc.active:
-            resp_id = (
-                existing_doc.id
-                if existing_doc.check_access_requirements(user, "read")
-                else None
-            )
-            payload = {"type": "document", "id": resp_id}
-            if resp_id is not None:
-                payload["duplicate_id"] = resp_id
-
-            return (
-                True,
-                409,
-                payload,
-                smsg.DOCUMENT_NAME_DUPLICATE,
+            return NameConflict(
+                code=409,
+                message=smsg.DOCUMENT_NAME_DUPLICATE,
+                data=_duplicate_payload(existing_doc, user, "document"),
             )
         inactive_docs.append(existing_doc)
 
     for existing_doc in inactive_docs:
         if not existing_doc.check_access_requirements(user, "write"):
-            resp_id = (
-                existing_doc.id
-                if existing_doc.check_access_requirements(user, "read")
-                else None
-            )
-            payload = {"type": "document", "id": resp_id}
-            if resp_id is not None:
-                payload["duplicate_id"] = resp_id
-
-            return (
-                True,
-                409,
-                payload,
-                getattr(
+            return NameConflict(
+                code=409,
+                message=getattr(
                     smsg,
                     "DENIED_FOR_DOC_NAME_DUPLICATE",
                     smsg.DOCUMENT_NAME_DUPLICATE,
                 ),
+                data=_duplicate_payload(existing_doc, user, "document"),
             )
 
     for existing_doc in inactive_docs:
         try:
             existing_doc.delete_all_revisions(do_commit=False)
         except PermissionError:
-            return (
-                True,
-                500,
-                {},
-                "Failed to delete revisions. Perhaps a file task is in progress?",
+            return NameConflict(
+                code=500,
+                message="Failed to delete revisions. Perhaps a file task is in progress?",
             )
         session.delete(existing_doc)
 
-    return False, 0, {}, ""
+    return None
+
+
+def reserve_name_for_write(
+    session: Session, user: User, folder_id: str | None, title: str
+) -> tuple[DirectoryNameLock | None, NameConflict | None]:
+    """
+    Reserve a parent/name pair until the caller finishes its write.
+
+    The returned lock must be released immediately before commit. Keeping it in
+    the transaction until then serializes concurrent writers for names that do
+    not yet exist in either the folders or documents table.
+    """
+    lock = acquire_name_write_lock(session, folder_id, title)
+    if isinstance(lock, NameConflict):
+        return None, lock
+
+    conflict = find_name_conflict(session, user, folder_id, title)
+    if conflict is not None:
+        return None, conflict
+
+    return lock, None
 
 
 def acquire_name_write_lock(
     session: Session, folder_id: str | None, title: str
-) -> tuple[bool, int, dict, str]:
+) -> DirectoryNameLock | NameConflict | None:
     if global_config["document"]["allow_name_duplicate"]:
-        return False, 0, {}, ""
+        return None
 
-    if not folder_id:
-        folder_id = ROOT_DIRECTORY_ID
+    folder_id = normalize_parent_id(folder_id)
     title = normalize_object_name(title)
 
     lock = DirectoryNameLock(parent_id=folder_id, name=title)
@@ -159,7 +181,13 @@ def acquire_name_write_lock(
             session.add(lock)
             session.flush()
     except IntegrityError:
-        session.rollback()
-        return True, 409, {}, smsg.DOCUMENT_OR_DIRECTORY_NAME_DUPLICATE
-    session.delete(lock)
-    return False, 0, {}, ""
+        return NameConflict(
+            code=409,
+            message=smsg.DOCUMENT_OR_DIRECTORY_NAME_DUPLICATE,
+        )
+    return lock
+
+
+def release_name_write_lock(session: Session, lock: DirectoryNameLock | None) -> None:
+    if lock is not None:
+        session.delete(lock)

--- a/src/include/domains/documents/commands/name_conflicts.py
+++ b/src/include/domains/documents/commands/name_conflicts.py
@@ -154,9 +154,10 @@ def acquire_name_write_lock(
     title = normalize_object_name(title)
 
     lock = DirectoryNameLock(parent_id=folder_id, name=title)
-    session.add(lock)
     try:
-        session.flush()
+        with session.begin_nested():
+            session.add(lock)
+            session.flush()
     except IntegrityError:
         session.rollback()
         return True, 409, {}, smsg.DOCUMENT_OR_DIRECTORY_NAME_DUPLICATE

--- a/src/include/domains/documents/handlers/directories.py
+++ b/src/include/domains/documents/handlers/directories.py
@@ -21,8 +21,8 @@ from include.domains.access.authorization.compiled_rules import (
 from include.domains.access.permissions import Permissions
 from include.domains.documents.commands.bulk_purge import purge_documents_bulk
 from include.domains.documents.commands.name_conflicts import (
-    normalize_object_name,
     release_name_write_lock,
+    require_object_name,
     reserve_name_for_write,
 )
 from include.domains.documents.queries.deletion_tree import fetch_subtree_for_deletion
@@ -293,13 +293,19 @@ class RequestCreateDirectoryHandler(RequestHandler):
     def handle(self, handler: ConnectionHandler):
         data = handler.data
         parent_id = data.get("parent_id")
-        name = normalize_object_name(data["name"])
+        name, validation_error = require_object_name(
+            data["name"], smsg.DIRECTORY_NAME_REQUIRED
+        )
         access_rules = data.get("access_rules", {})
         exists_ok = data.get("exists_ok", False)
         inherit_parent = data.get("inherit_parent", True)
 
-        if not name:
-            handler.conclude_request(400, {}, "Directory name is required")
+        if validation_error is not None:
+            handler.conclude_request(
+                validation_error.code,
+                validation_error.public_data(),
+                validation_error.message,
+            )
             return Result(code=400, target=parent_id, username=handler.username)
 
         if not parent_id:
@@ -536,13 +542,19 @@ class RequestRenameDirectoryHandler(RequestHandler):
 
         # Parse the directory renaming request
         folder_id = handler.data["folder_id"]
-        new_name = normalize_object_name(handler.data["new_name"])
+        new_name, validation_error = require_object_name(
+            handler.data["new_name"], smsg.DIRECTORY_NAME_REQUIRED
+        )
 
         if folder_id == ROOT_DIRECTORY_ID:
             handler.conclude_request(404, {}, smsg.DIRECTORY_NOT_FOUND)
             return Result(code=404, target=folder_id, username=handler.username)
-        if not new_name:
-            handler.conclude_request(400, {}, "Directory name is required")
+        if validation_error is not None:
+            handler.conclude_request(
+                validation_error.code,
+                validation_error.public_data(),
+                validation_error.message,
+            )
             return Result(code=400, target=folder_id, username=handler.username)
 
         with Session() as session:
@@ -958,9 +970,15 @@ class RequestRestoreDirectoryHandler(RequestHandler):
             else:
                 db_parent_id = folder.parent_id or ROOT_DIRECTORY_ID
 
-            final_name = normalize_object_name(new_name if new_name else folder.name)
-            if not final_name:
-                handler.conclude_request(400, {}, "Directory name is required")
+            final_name, validation_error = require_object_name(
+                new_name if new_name else folder.name, smsg.DIRECTORY_NAME_REQUIRED
+            )
+            if validation_error is not None:
+                handler.conclude_request(
+                    validation_error.code,
+                    validation_error.public_data(),
+                    validation_error.message,
+                )
                 return Result(code=400, target=folder_id, username=handler.username)
 
             target_parent = (

--- a/src/include/domains/documents/handlers/directories.py
+++ b/src/include/domains/documents/handlers/directories.py
@@ -21,9 +21,9 @@ from include.domains.access.authorization.compiled_rules import (
 from include.domains.access.permissions import Permissions
 from include.domains.documents.commands.bulk_purge import purge_documents_bulk
 from include.domains.documents.commands.name_conflicts import (
-    acquire_name_write_lock,
-    handle_name_duplicate,
     normalize_object_name,
+    release_name_write_lock,
+    reserve_name_for_write,
 )
 from include.domains.documents.queries.deletion_tree import fetch_subtree_for_deletion
 from include.domains.documents.queries.listing import (
@@ -331,20 +331,16 @@ class RequestCreateDirectoryHandler(RequestHandler):
                     handler.conclude_access_denial()
                     return Result(code=403, target=parent_id, username=handler.username)
 
-            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
-                session, parent_id, name
+            name_lock, conflict = reserve_name_for_write(
+                session, this_user, parent_id, name
             )
-            if not has_conflict:
-                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                    session, this_user, parent_id, name
-                )
-            if has_conflict:
+            if conflict is not None:
                 if (
                     exists_ok
-                    and err_data.get("type") == "directory"
-                    and err_data.get("entity")
+                    and conflict.data.get("type") == "directory"
+                    and conflict.data.get("entity")
                 ):
-                    existing_folder = err_data["entity"]
+                    existing_folder = conflict.data["entity"]
                     handler.conclude_request(
                         200,
                         {
@@ -356,13 +352,13 @@ class RequestCreateDirectoryHandler(RequestHandler):
                     )
                     return Result(code=0, target=parent_id, username=handler.username)
                 else:
-                    err_data_filtered = {
-                        k: v for k, v in err_data.items() if k != "entity"
-                    }
-                    handler.conclude_request(err_code, err_data_filtered, err_msg)
+                    err_data_filtered = conflict.public_data()
+                    handler.conclude_request(
+                        conflict.code, err_data_filtered, conflict.message
+                    )
                     if "duplicate_id" in err_data_filtered:
                         return Result(
-                            code=err_code,
+                            code=conflict.code,
                             target=parent_id,
                             data={
                                 "name": name,
@@ -371,7 +367,7 @@ class RequestCreateDirectoryHandler(RequestHandler):
                             username=handler.username,
                         )
                     return Result(
-                        code=err_code, target=parent_id, username=handler.username
+                        code=conflict.code, target=parent_id, username=handler.username
                     )
 
             folder = Folder(name=name, parent=parent)
@@ -381,6 +377,7 @@ class RequestCreateDirectoryHandler(RequestHandler):
                 handler.conclude_access_denial()
                 return Result(code=403, target=parent_id, username=handler.username)
 
+            release_name_write_lock(session, name_lock)
             session.commit()
 
             handler.conclude_request(
@@ -582,19 +579,17 @@ class RequestRenameDirectoryHandler(RequestHandler):
                 )
                 return
 
-            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
-                session, folder.parent_id, new_name
+            name_lock, conflict = reserve_name_for_write(
+                session, this_user, folder.parent_id, new_name
             )
-            if not has_conflict:
-                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                    session, this_user, folder.parent_id, new_name
+            if conflict is not None:
+                err_data_filtered = conflict.public_data()
+                handler.conclude_request(
+                    conflict.code, err_data_filtered, conflict.message
                 )
-            if has_conflict:
-                err_data_filtered = {k: v for k, v in err_data.items() if k != "entity"}
-                handler.conclude_request(err_code, err_data_filtered, err_msg)
                 if "duplicate_id" in err_data_filtered:
                     return Result(
-                        code=err_code,
+                        code=conflict.code,
                         target=folder_id,
                         data={
                             "title": new_name,
@@ -603,10 +598,11 @@ class RequestRenameDirectoryHandler(RequestHandler):
                         username=handler.username,
                     )
                 return Result(
-                    code=err_code, target=folder_id, username=handler.username
+                    code=conflict.code, target=folder_id, username=handler.username
                 )
 
             folder.name = new_name
+            release_name_write_lock(session, name_lock)
             session.commit()
 
             handler.conclude_request(
@@ -702,19 +698,17 @@ class RequestMoveDirectoryHandler(RequestHandler):
                 )
                 return Result(code=400, target=folder_id, username=handler.username)
 
-            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
-                session, target_folder_id, folder.name
+            name_lock, conflict = reserve_name_for_write(
+                session, user, target_folder_id, folder.name
             )
-            if not has_conflict:
-                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                    session, user, target_folder_id, folder.name
+            if conflict is not None:
+                err_data_filtered = conflict.public_data()
+                handler.conclude_request(
+                    conflict.code, err_data_filtered, conflict.message
                 )
-            if has_conflict:
-                err_data_filtered = {k: v for k, v in err_data.items() if k != "entity"}
-                handler.conclude_request(err_code, err_data_filtered, err_msg)
                 if "duplicate_id" in err_data_filtered:
                     return Result(
-                        code=err_code,
+                        code=conflict.code,
                         target=folder_id,
                         data={
                             "title": folder.name,
@@ -723,11 +717,12 @@ class RequestMoveDirectoryHandler(RequestHandler):
                         username=handler.username,
                     )
                 return Result(
-                    code=err_code, target=folder_id, username=handler.username
+                    code=conflict.code, target=folder_id, username=handler.username
                 )
 
             folder.parent = target_folder
 
+            release_name_write_lock(session, name_lock)
             session.commit()
 
         handler.conclude_request(200, {}, smsg.SUCCESS)
@@ -983,20 +978,17 @@ class RequestRestoreDirectoryHandler(RequestHandler):
                 handler.conclude_access_denial()
                 return Result(code=403, target=db_parent_id, username=handler.username)
 
-            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
-                session, db_parent_id, final_name
+            name_lock, conflict = reserve_name_for_write(
+                session, user, db_parent_id, final_name
             )
-            if not has_conflict:
-                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                    session, user, db_parent_id, final_name
-                )
-
-            if has_conflict:
+            if conflict is not None:
                 handler.conclude_request(
-                    err_code, {"conflict_id": err_data.get("duplicate_id")}, err_msg
+                    conflict.code,
+                    {"conflict_id": conflict.data.get("duplicate_id")},
+                    conflict.message,
                 )
                 return Result(
-                    code=err_code, target=folder_id, username=handler.username
+                    code=conflict.code, target=folder_id, username=handler.username
                 )
 
             op_id = folder.status_operation_id
@@ -1026,6 +1018,7 @@ class RequestRestoreDirectoryHandler(RequestHandler):
             folder.name = final_name
             folder.parent_id = db_parent_id
 
+            release_name_write_lock(session, name_lock)
             session.commit()
 
             handler.conclude_request(

--- a/src/include/domains/documents/handlers/directories.py
+++ b/src/include/domains/documents/handlers/directories.py
@@ -21,7 +21,9 @@ from include.domains.access.authorization.compiled_rules import (
 from include.domains.access.permissions import Permissions
 from include.domains.documents.commands.bulk_purge import purge_documents_bulk
 from include.domains.documents.commands.name_conflicts import (
+    acquire_name_write_lock,
     handle_name_duplicate,
+    normalize_object_name,
 )
 from include.domains.documents.queries.deletion_tree import fetch_subtree_for_deletion
 from include.domains.documents.queries.listing import (
@@ -291,10 +293,14 @@ class RequestCreateDirectoryHandler(RequestHandler):
     def handle(self, handler: ConnectionHandler):
         data = handler.data
         parent_id = data.get("parent_id")
-        name = data["name"]
+        name = normalize_object_name(data["name"])
         access_rules = data.get("access_rules", {})
         exists_ok = data.get("exists_ok", False)
         inherit_parent = data.get("inherit_parent", True)
+
+        if not name:
+            handler.conclude_request(400, {}, "Directory name is required")
+            return Result(code=400, target=parent_id, username=handler.username)
 
         if not parent_id:
             parent_id = ROOT_DIRECTORY_ID
@@ -325,9 +331,13 @@ class RequestCreateDirectoryHandler(RequestHandler):
                     handler.conclude_access_denial()
                     return Result(code=403, target=parent_id, username=handler.username)
 
-            has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                session, this_user, parent_id, name
+            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
+                session, parent_id, name
             )
+            if not has_conflict:
+                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
+                    session, this_user, parent_id, name
+                )
             if has_conflict:
                 if (
                     exists_ok
@@ -529,11 +539,14 @@ class RequestRenameDirectoryHandler(RequestHandler):
 
         # Parse the directory renaming request
         folder_id = handler.data["folder_id"]
-        new_name = handler.data["new_name"]
+        new_name = normalize_object_name(handler.data["new_name"])
 
         if folder_id == ROOT_DIRECTORY_ID:
             handler.conclude_request(404, {}, smsg.DIRECTORY_NOT_FOUND)
             return Result(code=404, target=folder_id, username=handler.username)
+        if not new_name:
+            handler.conclude_request(400, {}, "Directory name is required")
+            return Result(code=400, target=folder_id, username=handler.username)
 
         with Session() as session:
             this_user = User.get_existing(session, handler.username)
@@ -569,9 +582,13 @@ class RequestRenameDirectoryHandler(RequestHandler):
                 )
                 return
 
-            has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                session, this_user, folder.parent_id, new_name
+            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
+                session, folder.parent_id, new_name
             )
+            if not has_conflict:
+                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
+                    session, this_user, folder.parent_id, new_name
+                )
             if has_conflict:
                 err_data_filtered = {k: v for k, v in err_data.items() if k != "entity"}
                 handler.conclude_request(err_code, err_data_filtered, err_msg)
@@ -685,9 +702,13 @@ class RequestMoveDirectoryHandler(RequestHandler):
                 )
                 return Result(code=400, target=folder_id, username=handler.username)
 
-            has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                session, user, target_folder_id, folder.name
+            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
+                session, target_folder_id, folder.name
             )
+            if not has_conflict:
+                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
+                    session, user, target_folder_id, folder.name
+                )
             if has_conflict:
                 err_data_filtered = {k: v for k, v in err_data.items() if k != "entity"}
                 handler.conclude_request(err_code, err_data_filtered, err_msg)
@@ -942,7 +963,10 @@ class RequestRestoreDirectoryHandler(RequestHandler):
             else:
                 db_parent_id = folder.parent_id or ROOT_DIRECTORY_ID
 
-            final_name = new_name if new_name else folder.name
+            final_name = normalize_object_name(new_name if new_name else folder.name)
+            if not final_name:
+                handler.conclude_request(400, {}, "Directory name is required")
+                return Result(code=400, target=folder_id, username=handler.username)
 
             target_parent = (
                 session.query(Folder)
@@ -959,30 +983,21 @@ class RequestRestoreDirectoryHandler(RequestHandler):
                 handler.conclude_access_denial()
                 return Result(code=403, target=db_parent_id, username=handler.username)
 
-            existing_conflict = (
-                session.query(Folder)
-                .with_for_update()
-                .filter(
-                    Folder.parent_id == db_parent_id,
-                    Folder.name == final_name,
-                    Folder.status == EntityStatus.OK,
-                )
-                .first()
-                or session.query(Document)
-                .with_for_update()
-                .filter(
-                    Document.folder_id == db_parent_id,
-                    Document.title == final_name,
-                    Document.status == EntityStatus.OK,
-                )
-                .first()
+            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
+                session, db_parent_id, final_name
             )
-
-            if existing_conflict:
-                handler.conclude_request(
-                    409, {"conflict_id": existing_conflict.id}, "Name conflict"
+            if not has_conflict:
+                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
+                    session, user, db_parent_id, final_name
                 )
-                return Result(code=409, target=folder_id, username=handler.username)
+
+            if has_conflict:
+                handler.conclude_request(
+                    err_code, {"conflict_id": err_data.get("duplicate_id")}, err_msg
+                )
+                return Result(
+                    code=err_code, target=folder_id, username=handler.username
+                )
 
             op_id = folder.status_operation_id
 

--- a/src/include/domains/documents/handlers/documents.py
+++ b/src/include/domains/documents/handlers/documents.py
@@ -42,8 +42,8 @@ from include.domains.access.authorization.compiled_rules import (
 from include.domains.access.permissions import Permissions
 from include.domains.documents.commands.name_conflicts import (
     get_target_folder_and_check_write,
-    normalize_object_name,
     release_name_write_lock,
+    require_object_name,
     reserve_name_for_write,
 )
 from include.exceptions.misc import NoActiveRevisionsError
@@ -301,12 +301,18 @@ class RequestCreateDocumentHandler(RequestHandler):
 
     def handle(self, handler: ConnectionHandler):
         folder_id = handler.data.get("folder_id") or ROOT_DIRECTORY_ID
-        title = normalize_object_name(handler.data.get("title") or "")
+        title, validation_error = require_object_name(
+            handler.data.get("title") or "", smsg.DOCUMENT_TITLE_REQUIRED
+        )
         access_rules = handler.data.get("access_rules") or {}
         inherit_parent = handler.data.get("inherit_parent", True)
 
-        if not title:
-            handler.conclude_request(400, {}, smsg.DOCUMENT_TITLE_REQUIRED)
+        if validation_error is not None:
+            handler.conclude_request(
+                validation_error.code,
+                validation_error.public_data(),
+                validation_error.message,
+            )
             return
 
         with Session() as session:
@@ -587,10 +593,16 @@ class RequestRenameDocumentHandler(RequestHandler):
 
         # Parse the directory renaming request
         document_id: str = handler.data["document_id"]
-        new_title: str = normalize_object_name(handler.data["new_title"])
+        new_title, validation_error = require_object_name(
+            handler.data["new_title"], smsg.DOCUMENT_TITLE_REQUIRED
+        )
 
-        if not new_title:
-            handler.conclude_request(400, {}, smsg.DOCUMENT_TITLE_REQUIRED)
+        if validation_error is not None:
+            handler.conclude_request(
+                validation_error.code,
+                validation_error.public_data(),
+                validation_error.message,
+            )
             return Result(code=400, target=document_id, username=handler.username)
 
         with Session() as session:
@@ -1069,11 +1081,16 @@ class RequestRestoreDocumentHandler(RequestHandler):
             else:
                 db_folder_id = document.folder_id or ROOT_DIRECTORY_ID
 
-            final_title = normalize_object_name(
-                new_title if new_title else document.title
+            final_title, validation_error = require_object_name(
+                new_title if new_title else document.title,
+                smsg.DOCUMENT_TITLE_REQUIRED,
             )
-            if not final_title:
-                handler.conclude_request(400, {}, smsg.DOCUMENT_TITLE_REQUIRED)
+            if validation_error is not None:
+                handler.conclude_request(
+                    validation_error.code,
+                    validation_error.public_data(),
+                    validation_error.message,
+                )
                 return Result(code=400, target=doc_id, username=handler.username)
 
             target_folder = session.get(

--- a/src/include/domains/documents/handlers/documents.py
+++ b/src/include/domains/documents/handlers/documents.py
@@ -41,10 +41,10 @@ from include.domains.access.authorization.compiled_rules import (
 )
 from include.domains.access.permissions import Permissions
 from include.domains.documents.commands.name_conflicts import (
-    acquire_name_write_lock,
     get_target_folder_and_check_write,
-    handle_name_duplicate,
     normalize_object_name,
+    release_name_write_lock,
+    reserve_name_for_write,
 )
 from include.exceptions.misc import NoActiveRevisionsError
 from include.messages import Messages as smsg
@@ -333,18 +333,16 @@ class RequestCreateDocumentHandler(RequestHandler):
                     username=handler.username,
                 )
 
-            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
-                session, folder_id, title
+            name_lock, conflict = reserve_name_for_write(
+                session, user, folder_id, title
             )
-            if not has_conflict:
-                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                    session, user, folder_id, title
+            if conflict is not None:
+                err_data_filtered = conflict.public_data()
+                handler.conclude_request(
+                    conflict.code, err_data_filtered, conflict.message
                 )
-            else:
-                err_data_filtered = {k: v for k, v in err_data.items() if k != "entity"}
-                handler.conclude_request(err_code, err_data_filtered, err_msg)
                 return Result(
-                    code=err_code,
+                    code=conflict.code,
                     target=folder_id,
                     data={
                         "title": title,
@@ -390,6 +388,7 @@ class RequestCreateDocumentHandler(RequestHandler):
                     )
 
                 new_document.current_revision = new_revision
+                release_name_write_lock(session, name_lock)
                 session.commit()
 
                 task_data = create_file_task(
@@ -622,19 +621,17 @@ class RequestRenameDocumentHandler(RequestHandler):
                 )
                 return
 
-            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
-                session, document.folder_id, new_title
+            name_lock, conflict = reserve_name_for_write(
+                session, this_user, document.folder_id, new_title
             )
-            if not has_conflict:
-                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                    session, this_user, document.folder_id, new_title
+            if conflict is not None:
+                err_data_filtered = conflict.public_data()
+                handler.conclude_request(
+                    conflict.code, err_data_filtered, conflict.message
                 )
-            if has_conflict:
-                err_data_filtered = {k: v for k, v in err_data.items() if k != "entity"}
-                handler.conclude_request(err_code, err_data_filtered, err_msg)
                 if "duplicate_id" in err_data_filtered:
                     return Result(
-                        code=err_code,
+                        code=conflict.code,
                         target=document.folder_id,
                         data={
                             "title": document.title,
@@ -643,11 +640,14 @@ class RequestRenameDocumentHandler(RequestHandler):
                         username=handler.username,
                     )
                 return Result(
-                    code=err_code, target=document.folder_id, username=handler.username
+                    code=conflict.code,
+                    target=document.folder_id,
+                    username=handler.username,
                 )
 
             document.title = new_title
             mark_document_modified(document, this_user.username)
+            release_name_write_lock(session, name_lock)
             session.commit()
 
             handler.conclude_request(
@@ -926,19 +926,17 @@ class RequestMoveDocumentHandler(RequestHandler):
                         username=handler.username,
                     )
 
-            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
-                session, target_folder_id, document.title
+            name_lock, conflict = reserve_name_for_write(
+                session, user, target_folder_id, document.title
             )
-            if not has_conflict:
-                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                    session, user, target_folder_id, document.title
+            if conflict is not None:
+                err_data_filtered = conflict.public_data()
+                handler.conclude_request(
+                    conflict.code, err_data_filtered, conflict.message
                 )
-            if has_conflict:
-                err_data_filtered = {k: v for k, v in err_data.items() if k != "entity"}
-                handler.conclude_request(err_code, err_data_filtered, err_msg)
                 if "duplicate_id" in err_data_filtered:
                     return Result(
-                        code=err_code,
+                        code=conflict.code,
                         target=document.folder_id,
                         data={
                             "title": document.title,
@@ -947,12 +945,15 @@ class RequestMoveDocumentHandler(RequestHandler):
                         username=handler.username,
                     )
                 return Result(
-                    code=err_code, target=document.folder_id, username=handler.username
+                    code=conflict.code,
+                    target=document.folder_id,
+                    username=handler.username,
                 )
 
             document.folder = target_folder
             mark_document_modified(document, user.username)
 
+            release_name_write_lock(session, name_lock)
             session.commit()
 
         handler.conclude_request(200, {}, smsg.SUCCESS)
@@ -1094,21 +1095,18 @@ class RequestRestoreDocumentHandler(RequestHandler):
                 )
                 return Result(code=409, target=doc_id, username=handler.username)
 
-            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
-                session, db_folder_id, final_title
+            name_lock, conflict = reserve_name_for_write(
+                session, user, db_folder_id, final_title
             )
-            if not has_conflict:
-                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                    session, user, db_folder_id, final_title
-                )
-
-            if has_conflict:
+            if conflict is not None:
                 handler.conclude_request(
-                    err_code,
-                    {"conflict_id": err_data.get("duplicate_id")},
-                    err_msg,
+                    conflict.code,
+                    {"conflict_id": conflict.data.get("duplicate_id")},
+                    conflict.message,
                 )
-                return Result(code=err_code, target=doc_id, username=handler.username)
+                return Result(
+                    code=conflict.code, target=doc_id, username=handler.username
+                )
 
             document.status = EntityStatus.OK
             document.status_operation_id = None
@@ -1116,6 +1114,7 @@ class RequestRestoreDocumentHandler(RequestHandler):
             document.folder_id = db_folder_id
             mark_document_modified(document, user.username)
 
+            release_name_write_lock(session, name_lock)
             session.commit()
 
             handler.conclude_request(

--- a/src/include/domains/documents/handlers/documents.py
+++ b/src/include/domains/documents/handlers/documents.py
@@ -41,8 +41,10 @@ from include.domains.access.authorization.compiled_rules import (
 )
 from include.domains.access.permissions import Permissions
 from include.domains.documents.commands.name_conflicts import (
+    acquire_name_write_lock,
     get_target_folder_and_check_write,
     handle_name_duplicate,
+    normalize_object_name,
 )
 from include.exceptions.misc import NoActiveRevisionsError
 from include.messages import Messages as smsg
@@ -299,7 +301,7 @@ class RequestCreateDocumentHandler(RequestHandler):
 
     def handle(self, handler: ConnectionHandler):
         folder_id = handler.data.get("folder_id") or ROOT_DIRECTORY_ID
-        title = (handler.data.get("title") or "").strip()
+        title = normalize_object_name(handler.data.get("title") or "")
         access_rules = handler.data.get("access_rules") or {}
         inherit_parent = handler.data.get("inherit_parent", True)
 
@@ -331,17 +333,22 @@ class RequestCreateDocumentHandler(RequestHandler):
                     username=handler.username,
                 )
 
-            has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                session, user, folder_id, title
+            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
+                session, folder_id, title
             )
-            if has_conflict:
-                handler.conclude_request(err_code, err_data, err_msg)
+            if not has_conflict:
+                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
+                    session, user, folder_id, title
+                )
+            else:
+                err_data_filtered = {k: v for k, v in err_data.items() if k != "entity"}
+                handler.conclude_request(err_code, err_data_filtered, err_msg)
                 return Result(
                     code=err_code,
                     target=folder_id,
                     data={
                         "title": title,
-                        "duplicate_id": err_data.get("duplicate_id"),
+                        "duplicate_id": err_data_filtered.get("duplicate_id"),
                     },
                     username=handler.username,
                 )
@@ -581,7 +588,11 @@ class RequestRenameDocumentHandler(RequestHandler):
 
         # Parse the directory renaming request
         document_id: str = handler.data["document_id"]
-        new_title: str = handler.data["new_title"]
+        new_title: str = normalize_object_name(handler.data["new_title"])
+
+        if not new_title:
+            handler.conclude_request(400, {}, smsg.DOCUMENT_TITLE_REQUIRED)
+            return Result(code=400, target=document_id, username=handler.username)
 
         with Session() as session:
             this_user = User.get_existing(session, handler.username)
@@ -611,9 +622,13 @@ class RequestRenameDocumentHandler(RequestHandler):
                 )
                 return
 
-            has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                session, this_user, document.folder_id, new_title
+            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
+                session, document.folder_id, new_title
             )
+            if not has_conflict:
+                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
+                    session, this_user, document.folder_id, new_title
+                )
             if has_conflict:
                 err_data_filtered = {k: v for k, v in err_data.items() if k != "entity"}
                 handler.conclude_request(err_code, err_data_filtered, err_msg)
@@ -911,9 +926,13 @@ class RequestMoveDocumentHandler(RequestHandler):
                         username=handler.username,
                     )
 
-            has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
-                session, user, target_folder_id, document.title
+            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
+                session, target_folder_id, document.title
             )
+            if not has_conflict:
+                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
+                    session, user, target_folder_id, document.title
+                )
             if has_conflict:
                 err_data_filtered = {k: v for k, v in err_data.items() if k != "entity"}
                 handler.conclude_request(err_code, err_data_filtered, err_msg)
@@ -1049,7 +1068,12 @@ class RequestRestoreDocumentHandler(RequestHandler):
             else:
                 db_folder_id = document.folder_id or ROOT_DIRECTORY_ID
 
-            final_title = new_title if new_title else document.title
+            final_title = normalize_object_name(
+                new_title if new_title else document.title
+            )
+            if not final_title:
+                handler.conclude_request(400, {}, smsg.DOCUMENT_TITLE_REQUIRED)
+                return Result(code=400, target=doc_id, username=handler.username)
 
             target_folder = session.get(
                 Folder, db_folder_id, execution_options={"include_deleted": True}
@@ -1070,32 +1094,21 @@ class RequestRestoreDocumentHandler(RequestHandler):
                 )
                 return Result(code=409, target=doc_id, username=handler.username)
 
-            existing_conflict = (
-                session.query(Document)
-                .with_for_update()
-                .filter(
-                    Document.folder_id == db_folder_id,
-                    Document.title == final_title,
-                    Document.status == EntityStatus.OK,
-                )
-                .first()
-                or session.query(Folder)
-                .with_for_update()
-                .filter(
-                    Folder.parent_id == db_folder_id,
-                    Folder.name == final_title,
-                    Folder.status == EntityStatus.OK,
-                )
-                .first()
+            has_conflict, err_code, err_data, err_msg = acquire_name_write_lock(
+                session, db_folder_id, final_title
             )
-
-            if existing_conflict:
-                handler.conclude_request(
-                    409,
-                    {"conflict_id": existing_conflict.id},
-                    f"Conflict: An active item named '{final_title}' already exists in the destination.",
+            if not has_conflict:
+                has_conflict, err_code, err_data, err_msg = handle_name_duplicate(
+                    session, user, db_folder_id, final_title
                 )
-                return Result(code=409, target=doc_id, username=handler.username)
+
+            if has_conflict:
+                handler.conclude_request(
+                    err_code,
+                    {"conflict_id": err_data.get("duplicate_id")},
+                    err_msg,
+                )
+                return Result(code=err_code, target=doc_id, username=handler.username)
 
             document.status = EntityStatus.OK
             document.status_operation_id = None

--- a/src/include/domains/pagination.py
+++ b/src/include/domains/pagination.py
@@ -94,9 +94,12 @@ def _b64_encode(raw: bytes) -> str:
 def _b64_decode(token: str) -> bytes:
     try:
         padding = "=" * (-len(token) % 4)
-        return base64.urlsafe_b64decode((token + padding).encode())
+        decoded = base64.urlsafe_b64decode((token + padding).encode())
     except Exception as exc:
         raise CursorError("Invalid cursor") from exc
+    if _b64_encode(decoded) != token:
+        raise CursorError("Invalid cursor")
+    return decoded
 
 
 def encode_cursor(

--- a/src/include/messages.py
+++ b/src/include/messages.py
@@ -38,6 +38,7 @@ class Messages(StrEnum):
     DOCUMENT_DOES_NOT_EXIST = _("Document does not exist")
 
     DIRECTORY_ID_REQUIRED = _("Directory ID is required")
+    DIRECTORY_NAME_REQUIRED = _("Directory name is required")
     DOCUMENT_ID_REQUIRED = _("Document ID is required")
     DOCUMENT_TITLE_REQUIRED = _("Document title is required")
 

--- a/tests/test_directories.py
+++ b/tests/test_directories.py
@@ -2,9 +2,14 @@
 Tests for directory management operations.
 """
 
+import secrets
+import sqlite3
+import time
+
 import pytest
 
 from tests.test_client import CFMSTestClient
+from tests.utils import assert_success
 
 
 class TestDirectoryOperations:
@@ -399,6 +404,183 @@ class TestDirectoryMove:
                     await authenticated_client.delete_directory(parent_id)
                 except Exception:
                     pass
+
+
+class TestDocumentDirectoryNameConflicts:
+    @pytest.mark.asyncio
+    async def test_directory_and_document_names_share_namespace(
+        self, authenticated_client: CFMSTestClient, document_factory
+    ):
+        suffix = secrets.token_hex(4)
+        parent = await authenticated_client.create_directory(
+            f"Conflict Parent {suffix}"
+        )
+        parent_id = assert_success(parent)["id"]
+        folder_name = f"Shared Name {suffix}"
+        doc_name = f"Shared Doc Name {suffix}"
+
+        folder = await authenticated_client.create_directory(folder_name, parent_id)
+        folder_id = assert_success(folder)["id"]
+        doc = await document_factory(doc_name, folder_id=parent_id)
+
+        try:
+            doc_conflict = await authenticated_client.create_document(
+                folder_name, folder_id=parent_id
+            )
+            assert doc_conflict["code"] == 409
+
+            folder_conflict = await authenticated_client.create_directory(
+                doc_name, parent_id
+            )
+            assert folder_conflict["code"] == 409
+        finally:
+            await authenticated_client.delete_document(doc["document_id"])
+            await authenticated_client.delete_directory(folder_id)
+            await authenticated_client.delete_directory(parent_id)
+
+    @pytest.mark.asyncio
+    async def test_inactive_document_does_not_hide_directory_conflict(
+        self, authenticated_client: CFMSTestClient
+    ):
+        suffix = secrets.token_hex(4)
+        parent = await authenticated_client.create_directory(
+            f"Inactive Conflict Parent {suffix}"
+        )
+        parent_id = assert_success(parent)["id"]
+        name = f"Inactive Shared {suffix}"
+        folder = await authenticated_client.create_directory(name, parent_id)
+        folder_id = assert_success(folder)["id"]
+        stale_doc_id = secrets.token_hex(32)
+        stale_file_id = secrets.token_hex(32)
+
+        stale_revision_id = secrets.token_hex(32)
+        now = time.time()
+        with sqlite3.connect("src/app.db") as connection:
+            connection.execute("PRAGMA foreign_keys=ON")
+            connection.execute(
+                """
+                INSERT INTO files (id, path, created_time, active)
+                VALUES (?, ?, ?, ?)
+                """,
+                (stale_file_id, f"content/files/test/{stale_file_id}", now, 0),
+            )
+            connection.execute(
+                """
+                INSERT INTO documents (
+                    id, title, created_time, folder_id, current_revision_id,
+                    inherit, status
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (stale_doc_id, name, now, parent_id, None, 1, 0),
+            )
+            connection.execute(
+                """
+                INSERT INTO document_revisions (
+                    id, document_id, file_id, created_time, status
+                )
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (stale_revision_id, stale_doc_id, stale_file_id, now, 0),
+            )
+            connection.execute(
+                "UPDATE documents SET current_revision_id = ? WHERE id = ?",
+                (stale_revision_id, stale_doc_id),
+            )
+
+        try:
+            doc_conflict = await authenticated_client.create_document(
+                name, folder_id=parent_id
+            )
+            assert doc_conflict["code"] == 409
+
+            folder_conflict = await authenticated_client.create_directory(
+                name, parent_id
+            )
+            assert folder_conflict["code"] == 409
+        finally:
+            with sqlite3.connect("src/app.db") as connection:
+                connection.execute("PRAGMA foreign_keys=ON")
+                connection.execute(
+                    "UPDATE documents SET current_revision_id = NULL WHERE id = ?",
+                    (stale_doc_id,),
+                )
+                connection.execute(
+                    "DELETE FROM document_revisions WHERE id = ?", (stale_revision_id,)
+                )
+                connection.execute(
+                    "DELETE FROM documents WHERE id = ?", (stale_doc_id,)
+                )
+                connection.execute("DELETE FROM files WHERE id = ?", (stale_file_id,))
+            await authenticated_client.delete_directory(folder_id)
+            await authenticated_client.delete_directory(parent_id)
+
+    @pytest.mark.asyncio
+    async def test_rename_move_and_restore_respect_name_conflicts(
+        self, authenticated_client: CFMSTestClient, document_factory
+    ):
+        suffix = secrets.token_hex(4)
+        parent = await authenticated_client.create_directory(
+            f"Mutation Conflict Parent {suffix}"
+        )
+        parent_id = assert_success(parent)["id"]
+        target = await authenticated_client.create_directory(
+            f"Mutation Conflict Target {suffix}"
+        )
+        target_id = assert_success(target)["id"]
+        folder_name = f"Mutation Folder {suffix}"
+        doc_name = f"Mutation Doc {suffix}"
+        folder = await authenticated_client.create_directory(folder_name, parent_id)
+        folder_id = assert_success(folder)["id"]
+        target_folder = await authenticated_client.create_directory(doc_name, target_id)
+        target_folder_id = assert_success(target_folder)["id"]
+        doc = await document_factory(doc_name, folder_id=parent_id)
+        restore_doc = await document_factory(
+            f"Restore Conflict {suffix}", folder_id=parent_id
+        )
+
+        try:
+            rename_conflict = await authenticated_client.rename_document(
+                doc["document_id"], folder_name
+            )
+            assert rename_conflict["code"] == 409
+
+            move_conflict = await authenticated_client.send_request(
+                "move_document",
+                {"document_id": doc["document_id"], "target_folder_id": target_id},
+            )
+            assert move_conflict["code"] == 409
+
+            delete_response = await authenticated_client.delete_document(
+                restore_doc["document_id"]
+            )
+            assert_success(delete_response)
+            restore_folder = await authenticated_client.create_directory(
+                restore_doc["title"], parent_id
+            )
+            restore_folder_id = assert_success(restore_folder)["id"]
+            restore_conflict = await authenticated_client.restore_document(
+                restore_doc["document_id"], target_folder_id=parent_id
+            )
+            assert restore_conflict["code"] == 409
+        finally:
+            for doc_id in (doc["document_id"], restore_doc["document_id"]):
+                try:
+                    await authenticated_client.delete_document(doc_id)
+                except Exception:
+                    pass
+            for folder_to_delete in (
+                locals().get("restore_folder_id"),
+                target_folder_id,
+                folder_id,
+                target_id,
+                parent_id,
+            ):
+                if folder_to_delete:
+                    try:
+                        await authenticated_client.delete_directory(folder_to_delete)
+                    except Exception:
+                        pass
 
 
 class TestDirectoryWithoutAuth:

--- a/tests/test_directories.py
+++ b/tests/test_directories.py
@@ -3,7 +3,6 @@ Tests for directory management operations.
 """
 
 import secrets
-import sqlite3
 import time
 
 import pytest
@@ -450,6 +449,71 @@ class TestDirectoryMove:
 
 
 class TestDocumentDirectoryNameConflicts:
+    @staticmethod
+    def _create_inactive_document(
+        stale_doc_id: str,
+        stale_file_id: str,
+        stale_revision_id: str,
+        name: str,
+        parent_id: str,
+    ) -> None:
+        from include.database.models.documents import (
+            Document,
+            DocumentRevision,
+            DocumentRevisionStatus,
+            EntityStatus,
+        )
+        from include.database.models.files import File
+        from include.database.session import Session
+
+        now = time.time()
+        with Session() as session:
+            stale_file = File(
+                id=stale_file_id,
+                path=f"content/files/test/{stale_file_id}",
+                created_time=now,
+                active=False,
+            )
+            stale_doc = Document(
+                id=stale_doc_id,
+                title=name,
+                created_time=now,
+                folder_id=parent_id,
+                inherit=True,
+                status=EntityStatus.OK,
+            )
+            stale_revision = DocumentRevision(
+                id=stale_revision_id,
+                document=stale_doc,
+                file=stale_file,
+                created_time=now,
+                status=DocumentRevisionStatus.OK,
+            )
+            stale_doc.current_revision = stale_revision
+            session.add(stale_doc)
+            session.commit()
+
+    @staticmethod
+    def _delete_inactive_document(stale_doc_id: str, stale_file_id: str) -> None:
+        from include.database.models.documents import Document
+        from include.database.models.files import File
+        from include.database.session import Session
+
+        with Session() as session:
+            stale_doc = session.get(
+                Document, stale_doc_id, execution_options={"include_deleted": True}
+            )
+            if stale_doc:
+                stale_doc.current_revision = None
+                session.flush()
+                session.delete(stale_doc)
+
+            stale_file = session.get(File, stale_file_id)
+            if stale_file:
+                session.delete(stale_file)
+
+            session.commit()
+
     @pytest.mark.asyncio
     async def test_directory_and_document_names_share_namespace(
         self, authenticated_client: CFMSTestClient, document_factory
@@ -483,8 +547,9 @@ class TestDocumentDirectoryNameConflicts:
 
     @pytest.mark.asyncio
     async def test_inactive_document_does_not_hide_directory_conflict(
-        self, authenticated_client: CFMSTestClient
+        self, authenticated_client: CFMSTestClient, monkeypatch, protected_test_config
     ):
+        monkeypatch.chdir(protected_test_config.src_dir)
         suffix = secrets.token_hex(4)
         parent = await authenticated_client.create_directory(
             f"Inactive Conflict Parent {suffix}"
@@ -497,39 +562,9 @@ class TestDocumentDirectoryNameConflicts:
         stale_file_id = secrets.token_hex(32)
 
         stale_revision_id = secrets.token_hex(32)
-        now = time.time()
-        with sqlite3.connect("src/app.db") as connection:
-            connection.execute("PRAGMA foreign_keys=ON")
-            connection.execute(
-                """
-                INSERT INTO files (id, path, created_time, active)
-                VALUES (?, ?, ?, ?)
-                """,
-                (stale_file_id, f"content/files/test/{stale_file_id}", now, 0),
-            )
-            connection.execute(
-                """
-                INSERT INTO documents (
-                    id, title, created_time, folder_id, current_revision_id,
-                    inherit, status
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?)
-                """,
-                (stale_doc_id, name, now, parent_id, None, 1, 0),
-            )
-            connection.execute(
-                """
-                INSERT INTO document_revisions (
-                    id, document_id, file_id, created_time, status
-                )
-                VALUES (?, ?, ?, ?, ?)
-                """,
-                (stale_revision_id, stale_doc_id, stale_file_id, now, 0),
-            )
-            connection.execute(
-                "UPDATE documents SET current_revision_id = ? WHERE id = ?",
-                (stale_revision_id, stale_doc_id),
-            )
+        self._create_inactive_document(
+            stale_doc_id, stale_file_id, stale_revision_id, name, parent_id
+        )
 
         try:
             doc_conflict = await authenticated_client.create_document(
@@ -542,19 +577,7 @@ class TestDocumentDirectoryNameConflicts:
             )
             assert folder_conflict["code"] == 409
         finally:
-            with sqlite3.connect("src/app.db") as connection:
-                connection.execute("PRAGMA foreign_keys=ON")
-                connection.execute(
-                    "UPDATE documents SET current_revision_id = NULL WHERE id = ?",
-                    (stale_doc_id,),
-                )
-                connection.execute(
-                    "DELETE FROM document_revisions WHERE id = ?", (stale_revision_id,)
-                )
-                connection.execute(
-                    "DELETE FROM documents WHERE id = ?", (stale_doc_id,)
-                )
-                connection.execute("DELETE FROM files WHERE id = ?", (stale_file_id,))
+            self._delete_inactive_document(stale_doc_id, stale_file_id)
             await authenticated_client.delete_directory(folder_id)
             await authenticated_client.delete_directory(parent_id)
 
@@ -624,6 +647,97 @@ class TestDocumentDirectoryNameConflicts:
                         await authenticated_client.delete_directory(folder_to_delete)
                     except Exception:
                         pass
+
+    @pytest.mark.asyncio
+    async def test_restore_document_ignores_deleted_self_conflict(
+        self, authenticated_client: CFMSTestClient, document_factory
+    ):
+        suffix = secrets.token_hex(4)
+        parent = await authenticated_client.create_directory(
+            f"Document Restore Parent {suffix}"
+        )
+        parent_id = assert_success(parent)["id"]
+        doc = await document_factory(
+            f"Document Restore Self {suffix}", folder_id=parent_id
+        )
+
+        try:
+            delete_response = await authenticated_client.delete_document(
+                doc["document_id"]
+            )
+            assert_success(delete_response)
+
+            restore_response = await authenticated_client.restore_document(
+                doc["document_id"], target_folder_id=parent_id
+            )
+            assert_success(restore_response)
+        finally:
+            try:
+                await authenticated_client.delete_document(doc["document_id"])
+            except Exception:
+                pass
+            await authenticated_client.delete_directory(parent_id)
+
+    @pytest.mark.asyncio
+    async def test_restore_inactive_document_ignores_deleted_self_conflict(
+        self, authenticated_client: CFMSTestClient, document_factory
+    ):
+        suffix = secrets.token_hex(4)
+        parent = await authenticated_client.create_directory(
+            f"Inactive Document Restore Parent {suffix}"
+        )
+        parent_id = assert_success(parent)["id"]
+        doc = await document_factory(
+            f"Inactive Document Restore Self {suffix}",
+            upload_file=None,
+            folder_id=parent_id,
+        )
+
+        try:
+            delete_response = await authenticated_client.delete_document(
+                doc["document_id"]
+            )
+            assert_success(delete_response)
+
+            restore_response = await authenticated_client.restore_document(
+                doc["document_id"], target_folder_id=parent_id
+            )
+            assert_success(restore_response)
+        finally:
+            try:
+                await authenticated_client.delete_document(doc["document_id"])
+            except Exception:
+                pass
+            await authenticated_client.delete_directory(parent_id)
+
+    @pytest.mark.asyncio
+    async def test_restore_directory_ignores_deleted_self_conflict(
+        self, authenticated_client: CFMSTestClient
+    ):
+        suffix = secrets.token_hex(4)
+        parent = await authenticated_client.create_directory(
+            f"Directory Restore Parent {suffix}"
+        )
+        parent_id = assert_success(parent)["id"]
+        folder = await authenticated_client.create_directory(
+            f"Directory Restore Self {suffix}", parent_id
+        )
+        folder_id = assert_success(folder)["id"]
+
+        try:
+            delete_response = await authenticated_client.delete_directory(folder_id)
+            assert_success(delete_response)
+
+            restore_response = await authenticated_client.restore_directory(
+                folder_id, target_parent_id=parent_id
+            )
+            assert_success(restore_response)
+        finally:
+            try:
+                await authenticated_client.delete_directory(folder_id)
+            except Exception:
+                pass
+            await authenticated_client.delete_directory(parent_id)
 
 
 class TestDirectoryWithoutAuth:

--- a/tests/test_directories.py
+++ b/tests/test_directories.py
@@ -4,6 +4,7 @@ Tests for directory management operations.
 
 import secrets
 import time
+from pathlib import Path
 
 import pytest
 from sqlalchemy import create_engine, select
@@ -450,12 +451,17 @@ class TestDirectoryMove:
 
 class TestDocumentDirectoryNameConflicts:
     @staticmethod
+    def _session_factory(db_path: Path):
+        return sessionmaker(bind=create_engine(f"sqlite:///{db_path.as_posix()}"))
+
+    @staticmethod
     def _create_inactive_document(
         stale_doc_id: str,
         stale_file_id: str,
         stale_revision_id: str,
         name: str,
         parent_id: str,
+        db_path: Path,
     ) -> None:
         from include.database.models.documents import (
             Document,
@@ -464,10 +470,9 @@ class TestDocumentDirectoryNameConflicts:
             EntityStatus,
         )
         from include.database.models.files import File
-        from include.database.session import Session
 
         now = time.time()
-        with Session() as session:
+        with TestDocumentDirectoryNameConflicts._session_factory(db_path)() as session:
             stale_file = File(
                 id=stale_file_id,
                 path=f"content/files/test/{stale_file_id}",
@@ -494,12 +499,13 @@ class TestDocumentDirectoryNameConflicts:
             session.commit()
 
     @staticmethod
-    def _delete_inactive_document(stale_doc_id: str, stale_file_id: str) -> None:
+    def _delete_inactive_document(
+        stale_doc_id: str, stale_file_id: str, db_path: Path
+    ) -> None:
         from include.database.models.documents import Document
         from include.database.models.files import File
-        from include.database.session import Session
 
-        with Session() as session:
+        with TestDocumentDirectoryNameConflicts._session_factory(db_path)() as session:
             stale_doc = session.get(
                 Document, stale_doc_id, execution_options={"include_deleted": True}
             )
@@ -562,8 +568,9 @@ class TestDocumentDirectoryNameConflicts:
         stale_file_id = secrets.token_hex(32)
 
         stale_revision_id = secrets.token_hex(32)
+        db_path = protected_test_config.src_dir / "app.db"
         self._create_inactive_document(
-            stale_doc_id, stale_file_id, stale_revision_id, name, parent_id
+            stale_doc_id, stale_file_id, stale_revision_id, name, parent_id, db_path
         )
 
         try:
@@ -577,7 +584,7 @@ class TestDocumentDirectoryNameConflicts:
             )
             assert folder_conflict["code"] == 409
         finally:
-            self._delete_inactive_document(stale_doc_id, stale_file_id)
+            self._delete_inactive_document(stale_doc_id, stale_file_id, db_path)
             await authenticated_client.delete_directory(folder_id)
             await authenticated_client.delete_directory(parent_id)
 

--- a/tests/test_directories.py
+++ b/tests/test_directories.py
@@ -7,9 +7,52 @@ import sqlite3
 import time
 
 import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
 
 from tests.test_client import CFMSTestClient
 from tests.utils import assert_success
+
+
+def test_name_write_lock_lives_until_explicit_release(
+    monkeypatch, protected_test_config
+):
+    monkeypatch.chdir(protected_test_config.src_dir)
+
+    from include.config.settings import global_config
+    from include.database.models.documents import DirectoryNameLock
+    from include.domains.documents.commands.name_conflicts import (
+        NameConflict,
+        acquire_name_write_lock,
+        release_name_write_lock,
+    )
+
+    monkeypatch.setitem(global_config["document"], "allow_name_duplicate", False)
+
+    engine = create_engine("sqlite:///:memory:")
+    DirectoryNameLock.__table__.create(engine)
+    session_factory = sessionmaker(bind=engine)
+
+    with session_factory() as session:
+        lock = acquire_name_write_lock(session, "parent", "Shared Name")
+
+        assert isinstance(lock, DirectoryNameLock)
+        assert session.scalar(select(DirectoryNameLock)) is lock
+        session.expunge(lock)
+        assert isinstance(
+            acquire_name_write_lock(session, "parent", "Shared Name"),
+            NameConflict,
+        )
+
+        lock = session.get(
+            DirectoryNameLock,
+            {"parent_id": "parent", "name": "Shared Name"},
+        )
+        release_name_write_lock(session, lock)
+        session.commit()
+
+    with session_factory() as session:
+        assert session.scalar(select(DirectoryNameLock)) is None
 
 
 class TestDirectoryOperations:


### PR DESCRIPTION
## Summary by Sourcery

Introduce a locking-based mechanism to prevent directory/document name conflicts and align handlers/tests with the new conflict semantics.

Bug Fixes:
- Harden cursor decoding to reject malformed base64 tokens instead of silently accepting them.

Enhancements:
- Treat directory and document names as a shared namespace with normalized names and explicit validation for required titles/names.
- Handle name conflicts through a structured NameConflict response object and centralized helpers, improving error reporting and reuse across handlers.
- Clean up stale inactive documents only when caller has sufficient permissions, while ensuring they no longer mask name conflicts.

Tests:
- Add comprehensive tests for directory/document name conflict scenarios, including rename, move, restore, inactive documents, and name-lock lifetime.

Chores:
- Add DirectoryNameLock model, Alembic migration, and wiring into SQLAlchemy models to support per-parent name reservations.