### PR TITLE
Enhance OpenID Connect SSO extension and related configurations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
     
     steps:
     - uses: actions/checkout@v6
+      with:
+        submodules: recursive
     
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
@@ -32,7 +34,7 @@ jobs:
     
     - name: Install dependencies
       run: |
-        uv sync --dev
+        uv sync --dev --all-extras
     
     - name: Create necessary directories
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     "watchdog>=6.0.0",
     "rich>=15.0.0",
     "typer>=0.26.7",
+    "authlib>=1.7.2",
+    "requests>=2.34.2",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,6 @@ dependencies = [
     "watchdog>=6.0.0",
     "rich>=15.0.0",
     "typer>=0.26.7",
-    "authlib>=1.7.2",
-    "requests>=2.34.2",
 ]
 
 [project.scripts]
@@ -36,6 +34,10 @@ cluster = [
 ]
 mysql = [
     "mysql-connector-python>=9.6.0",
+]
+ext_oidc_sso = [
+    "authlib>=1.7.2",
+    "requests>=2.34.2",
 ]
 
 [dependency-groups]

--- a/src/alembic/versions/6cc4a094da7a_set_null_on_document_revision_references.py
+++ b/src/alembic/versions/6cc4a094da7a_set_null_on_document_revision_references.py
@@ -1,0 +1,165 @@
+"""set null on document revision references
+
+Revision ID: 6cc4a094da7a
+Revises: 0b73fbf3e15a
+Create Date: 2026-07-09 19:29:57.252644
+
+"""
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "6cc4a094da7a"
+down_revision: str | Sequence[str] | None = "0b73fbf3e15a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+NAMING_CONVENTION = {
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+}
+
+
+def _find_fk_name(
+    inspector: sa.engine.reflection.Inspector,
+    table_name: str,
+    constrained_columns: list[str],
+    referred_table: str,
+    referred_columns: list[str],
+) -> str:
+    for fk in inspector.get_foreign_keys(table_name):
+        if (
+            fk.get("constrained_columns") == constrained_columns
+            and fk.get("referred_table") == referred_table
+            and fk.get("referred_columns") == referred_columns
+        ):
+            return fk.get("name") or (
+                f"fk_{table_name}_{constrained_columns[0]}_{referred_table}"
+            )
+
+    raise RuntimeError(
+        "Could not find foreign key on "
+        f"{table_name}({', '.join(constrained_columns)})"
+    )
+
+
+def _clear_orphan_revision_references() -> None:
+    bind = op.get_bind()
+    bind.execute(
+        sa.text(
+            """
+            UPDATE documents
+            SET current_revision_id = NULL
+            WHERE current_revision_id IS NOT NULL
+            AND NOT EXISTS (
+                SELECT 1
+                FROM document_revisions
+                WHERE document_revisions.id = documents.current_revision_id
+            )
+            """
+        )
+    )
+    bind.execute(
+        sa.text(
+            """
+            UPDATE document_revisions
+            SET parent_revision_id = NULL
+            WHERE parent_revision_id IS NOT NULL
+            AND NOT EXISTS (
+                SELECT 1
+                FROM document_revisions AS parent_revisions
+                WHERE parent_revisions.id = document_revisions.parent_revision_id
+            )
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    _clear_orphan_revision_references()
+    inspector = sa.inspect(op.get_bind())
+    parent_revision_fk_name = _find_fk_name(
+        inspector,
+        "document_revisions",
+        ["parent_revision_id"],
+        "document_revisions",
+        ["id"],
+    )
+    current_revision_fk_name = _find_fk_name(
+        inspector,
+        "documents",
+        ["current_revision_id"],
+        "document_revisions",
+        ["id"],
+    )
+
+    with op.batch_alter_table(
+        "document_revisions", schema=None, naming_convention=NAMING_CONVENTION
+    ) as batch_op:
+        batch_op.drop_constraint(parent_revision_fk_name, type_="foreignkey")
+        batch_op.create_foreign_key(
+            batch_op.f("fk_document_revisions_parent_revision_id_document_revisions"),
+            "document_revisions",
+            ["parent_revision_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+    with op.batch_alter_table(
+        "documents", schema=None, naming_convention=NAMING_CONVENTION
+    ) as batch_op:
+        batch_op.drop_constraint(current_revision_fk_name, type_="foreignkey")
+        batch_op.create_foreign_key(
+            batch_op.f("fk_documents_current_revision_id_document_revisions"),
+            "document_revisions",
+            ["current_revision_id"],
+            ["id"],
+            ondelete="SET NULL",
+            use_alter=True,
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    _clear_orphan_revision_references()
+    inspector = sa.inspect(op.get_bind())
+    current_revision_fk_name = _find_fk_name(
+        inspector,
+        "documents",
+        ["current_revision_id"],
+        "document_revisions",
+        ["id"],
+    )
+    parent_revision_fk_name = _find_fk_name(
+        inspector,
+        "document_revisions",
+        ["parent_revision_id"],
+        "document_revisions",
+        ["id"],
+    )
+
+    with op.batch_alter_table(
+        "documents", schema=None, naming_convention=NAMING_CONVENTION
+    ) as batch_op:
+        batch_op.drop_constraint(current_revision_fk_name, type_="foreignkey")
+        batch_op.create_foreign_key(
+            batch_op.f("fk_documents_current_revision_id"),
+            "document_revisions",
+            ["current_revision_id"],
+            ["id"],
+        )
+
+    with op.batch_alter_table(
+        "document_revisions", schema=None, naming_convention=NAMING_CONVENTION
+    ) as batch_op:
+        batch_op.drop_constraint(parent_revision_fk_name, type_="foreignkey")
+        batch_op.create_foreign_key(
+            batch_op.f("fk_document_revisions_parent_revision_id_document_revisions"),
+            "document_revisions",
+            ["parent_revision_id"],
+            ["id"],
+        )

--- a/src/config.toml.sample
+++ b/src/config.toml.sample
@@ -61,6 +61,23 @@ require_client_cert = false
 # Only takes effect when require_client_cert is true.
 client_cert_ca_path = "./content/ssl/client/"
 
+[sso.oidc]
+# Enable OpenID Connect single sign-on.
+enabled = false
+# Issuer URL of the OpenID Provider, without a trailing slash.
+issuer = ""
+# OAuth/OIDC client credentials registered with the provider.
+client_id = ""
+client_secret = ""
+# Redirect URI registered with the provider and used by the client.
+redirect_uri = ""
+# Claim used to map the external identity to a CFMS username.
+username_claim = "preferred_username"
+# Automatically create local users when the mapped username does not exist.
+auto_provision = false
+# Groups assigned to auto-provisioned users.
+default_groups = ["user"]
+
 [access]
 # Enable recursive access checks.
 # When enabled, access rules will be checked for the requested object itself, 

--- a/src/include/database/models/documents.py
+++ b/src/include/database/models/documents.py
@@ -284,7 +284,7 @@ class Document(Node):
         VARCHAR(64),
         ForeignKey(
             "document_revisions.id",
-            name="fk_documents_current_revision_id",
+            ondelete="SET NULL",
             use_alter=True,
         ),
         nullable=True,
@@ -464,7 +464,9 @@ class DocumentRevision(Base):
     )
 
     parent_revision_id: Mapped[str | None] = mapped_column(
-        VARCHAR(64), ForeignKey("document_revisions.id"), nullable=True
+        VARCHAR(64),
+        ForeignKey("document_revisions.id", ondelete="SET NULL"),
+        nullable=True,
     )
     parent_revision: Mapped[DocumentRevision | None] = relationship(
         "DocumentRevision",

--- a/src/include/domains/identity/handlers/auth.py
+++ b/src/include/domains/identity/handlers/auth.py
@@ -3,8 +3,8 @@ from typing import Any
 
 from include.config.settings import global_config
 from include.database.models.identity import User
-from include.database.models.keyrings import UserKey
 from include.database.session import Session
+from include.domains.identity.sessions import build_login_success_data
 from include.domains.identity.validators.passwords import check_passwd_requirements
 from include.domains.operations.commands.audit import log_audit
 from include.domains.security.guards.login import LoginGuard
@@ -98,25 +98,9 @@ class RequestLoginHandler(RequestHandler):
                         4002, "Password should be changed because it's expired"
                     )
 
-            success_data = {
-                "token": token.raw,
-                "exp": token.exp,
-                "nickname": user.nickname,
-                "avatar_id": user.avatar_id,
-                "permissions": list(user.all_permissions),
-                "groups": list(user.all_groups),
-            }
-
-            if user.preference_dek_id:
-                preference_dek = session.get(UserKey, user.preference_dek_id)
-                if preference_dek:
-                    success_data["preference_dek"] = {
-                        "key_id": preference_dek.id,
-                        "key_content": preference_dek.content,
-                        "label": preference_dek.label,
-                    }
-
-            return respond(200, "Login successful", success_data)
+            return respond(
+                200, "Login successful", build_login_success_data(session, user, token)
+            )
 
 
 class RequestRefreshTokenHandler(RequestHandler):

--- a/src/include/domains/identity/sessions.py
+++ b/src/include/domains/identity/sessions.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from sqlalchemy.orm import Session as ORMSession
+from sqlalchemy.orm import object_session
+
+from include.database.models.identity import User, UserStatus
+from include.database.models.keyrings import UserKey
+from include.domains.identity.tokens import Token
+from include.exceptions.misc import UserNotActiveError
+
+
+def issue_login_token(user: User) -> Token:
+    if user.status != UserStatus.ACTIVE:
+        raise UserNotActiveError
+
+    token = user.renew_token()
+    session = object_session(user)
+    if session is not None:
+        user.last_login = time.time()
+        session.add(user)
+        session.commit()
+
+    return token
+
+
+def build_login_success_data(
+    session: ORMSession,
+    user: User,
+    token: Token,
+) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "token": token.raw,
+        "exp": token.exp,
+        "nickname": user.nickname,
+        "avatar_id": user.avatar_id,
+        "permissions": list(user.all_permissions),
+        "groups": list(user.all_groups),
+    }
+
+    if user.preference_dek_id:
+        preference_dek = session.get(UserKey, user.preference_dek_id)
+        if preference_dek:
+            data["preference_dek"] = {
+                "key_id": preference_dek.id,
+                "key_content": preference_dek.content,
+                "label": preference_dek.label,
+            }
+
+    return data

--- a/src/include/domains/identity/sessions.py
+++ b/src/include/domains/identity/sessions.py
@@ -1,10 +1,8 @@
 from __future__ import annotations
 
-import time
 from typing import Any
 
 from sqlalchemy.orm import Session as ORMSession
-from sqlalchemy.orm import object_session
 
 from include.database.models.identity import User, UserStatus
 from include.database.models.keyrings import UserKey
@@ -16,14 +14,7 @@ def issue_login_token(user: User) -> Token:
     if user.status != UserStatus.ACTIVE:
         raise UserNotActiveError
 
-    token = user.renew_token()
-    session = object_session(user)
-    if session is not None:
-        user.last_login = time.time()
-        session.add(user)
-        session.commit()
-
-    return token
+    return user.renew_token()
 
 
 def build_login_success_data(

--- a/src/include/extensions/builtin/_extension.py
+++ b/src/include/extensions/builtin/_extension.py
@@ -13,7 +13,7 @@ from include.database.models.identity import User
 from include.database.session import Session
 from include.domains.access.permissions import Permissions
 from include.domains.documents.queries.file_references import _get_file_references
-from include.extensions.manager import hookimpl
+from include.extensions.manager import collect_extension_flags, hookimpl
 from include.messages import Messages as smsg
 from include.shared import lockdown_enabled
 from include.transport.connection import ConnectionHandler
@@ -39,6 +39,7 @@ class RequestServerInfoHandler(RequestHandler):
             "version": CORE_VERSION.original,
             "protocol_version": PROTOCOL_VERSION,
             "lockdown": lockdown_enabled.is_set(),
+            "extension_flags": collect_extension_flags(),
         }
         handler.conclude_request(
             200, server_info, "Server information retrieved successfully"

--- a/src/include/extensions/manager.py
+++ b/src/include/extensions/manager.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-__all__ = ["pm", "load_builtin_extension", "load_extensions_from_directory"]
+__all__ = [
+    "pm",
+    "collect_extension_flags",
+    "load_builtin_extension",
+    "load_extensions_from_directory",
+]
 
 import importlib.util
 import os
@@ -28,8 +33,7 @@ class ServerHookSpecs:
 
     @hookspec
     def ext_register_handlers(self) -> dict[str, type[RequestHandler]]:
-        """
-        Register handlers for specific actions.
+        """Register handlers for specific actions.
 
         Should return a dictionary mapping action names to their
         corresponding RequestHandler classes.
@@ -38,8 +42,7 @@ class ServerHookSpecs:
 
     @hookspec
     def ext_unregister_handlers(self) -> set[str]:
-        """
-        Unregister handlers for specific actions.
+        """Unregister handlers for specific actions.
 
         Should return a set of action names whose handlers should
         be unregistered.
@@ -53,6 +56,15 @@ class ServerHookSpecs:
         during lockdown).
 
         Should return a set of action names.
+        """
+        ...
+
+    @hookspec
+    def ext_register_extension_flags(self) -> set[str]:
+        """
+        Register extension capability flags advertised by server_info.
+
+        Should return a set of string flags that are currently enabled.
         """
         ...
 
@@ -188,6 +200,23 @@ def load_extensions_from_directory(extension_dir: str | Path):
             continue
 
         loaded_extensions.add(ext_name)
+
+
+def collect_extension_flags() -> list[str]:
+    flags: set[str] = set()
+
+    for registered_flags in pm.hook.ext_register_extension_flags():
+        if registered_flags is None:
+            continue
+
+        for flag in registered_flags:
+            if not isinstance(flag, str):
+                logger.warning(f"Ignoring non-string extension flag: {flag!r}")
+                continue
+
+            flags.add(flag)
+
+    return sorted(flags)
 
 
 pm = pluggy.PluginManager("cfms")

--- a/src/include/extensions/manager.py
+++ b/src/include/extensions/manager.py
@@ -206,9 +206,6 @@ def collect_extension_flags() -> list[str]:
     flags: set[str] = set()
 
     for registered_flags in pm.hook.ext_register_extension_flags():
-        if registered_flags is None:
-            continue
-
         for flag in registered_flags:
             if not isinstance(flag, str):
                 logger.warning(f"Ignoring non-string extension flag: {flag!r}")

--- a/src/include/extensions/oidc_sso/_extension.py
+++ b/src/include/extensions/oidc_sso/_extension.py
@@ -453,3 +453,11 @@ def ext_register_handlers() -> dict[str, type[RequestHandler]]:
 @hookimpl
 def ext_register_whitelisted_actions() -> set[str]:
     return {"sso_oidc_start", "sso_oidc_callback"}
+
+
+@hookimpl
+def ext_register_extension_flags() -> set[str]:
+    if not _get_oidc_config()["enabled"]:
+        return set()
+
+    return {"oidc_sso"}

--- a/src/include/extensions/oidc_sso/_extension.py
+++ b/src/include/extensions/oidc_sso/_extension.py
@@ -1,3 +1,11 @@
+"""
+OIDC SSO extension for CFMS, providing OpenID Connect Single Sign-On support.
+
+This extension was primarily written by a large language model and was created for
+experimental purposes. We make no guarantees regarding the functional reliability
+of this extension.
+"""
+
 from __future__ import annotations
 
 import base64

--- a/src/include/extensions/oidc_sso/_extension.py
+++ b/src/include/extensions/oidc_sso/_extension.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+import time
+from typing import Any
+
+import jwt
+import orjson
+import requests
+from authlib.integrations.requests_client import OAuth2Session
+from loguru import logger as log
+
+from include.config.settings import global_config
+from include.database.models.identity import User, UserGroup
+from include.database.session import Session
+from include.domains.identity.commands.users import create_user
+from include.domains.identity.sessions import (
+    build_login_success_data,
+    issue_login_token,
+)
+from include.exceptions.misc import UserNotActiveError
+from include.extensions.manager import hookimpl
+from include.providers.manager import ProviderManager
+from include.transport.connection import ConnectionHandler
+from include.transport.request_handler import RequestHandler, Result
+
+logger = log.bind(name="oidc_sso")
+
+STATE_CACHE_PREFIX = "oidc_sso:state:"
+METADATA_CACHE_PREFIX = "oidc_sso:metadata:"
+DEFAULT_STATE_TTL_SECONDS = 300
+DEFAULT_HTTP_TIMEOUT_SECONDS = 10
+DEFAULT_SCOPE = "openid profile email"
+
+
+class OIDCConfigurationError(ValueError):
+    pass
+
+
+class OIDCAuthenticationError(ValueError):
+    pass
+
+
+def _as_plain(value: Any) -> Any:
+    if hasattr(value, "unwrap"):
+        return value.unwrap()
+    return value
+
+
+def _get_oidc_config() -> dict[str, Any]:
+    sso_cfg = _as_plain(global_config.get("sso", {})) or {}
+    oidc_cfg = _as_plain(sso_cfg.get("oidc", {})) or {}
+
+    issuer = str(oidc_cfg.get("issuer", "")).rstrip("/")
+    client_id = str(oidc_cfg.get("client_id", ""))
+    redirect_uri = str(oidc_cfg.get("redirect_uri", ""))
+
+    return {
+        "enabled": bool(oidc_cfg.get("enabled", False)),
+        "issuer": issuer,
+        "client_id": client_id,
+        "client_secret": str(oidc_cfg.get("client_secret", "")),
+        "redirect_uri": redirect_uri,
+        "username_claim": str(oidc_cfg.get("username_claim", "preferred_username")),
+        "auto_provision": bool(oidc_cfg.get("auto_provision", False)),
+        "default_groups": list(oidc_cfg.get("default_groups", ["user"])),
+        "state_ttl_seconds": int(
+            oidc_cfg.get("state_ttl_seconds", DEFAULT_STATE_TTL_SECONDS)
+        ),
+        "scope": str(oidc_cfg.get("scope", DEFAULT_SCOPE)),
+    }
+
+
+def _require_enabled_config() -> dict[str, Any]:
+    cfg = _get_oidc_config()
+    if not cfg["enabled"]:
+        raise OIDCConfigurationError("OIDC SSO is disabled")
+
+    missing = [
+        name for name in ("issuer", "client_id", "redirect_uri") if not cfg.get(name)
+    ]
+    if missing:
+        raise OIDCConfigurationError(
+            "OIDC SSO configuration is missing: " + ", ".join(missing)
+        )
+
+    if cfg["state_ttl_seconds"] <= 0:
+        raise OIDCConfigurationError("OIDC state_ttl_seconds must be positive")
+
+    return cfg
+
+
+def _cache_get(key: str) -> Any:
+    return ProviderManager().caching.get(key)
+
+
+def _cache_set(key: str, value: Any, ttl: float, nx: bool = False) -> bool:
+    return ProviderManager().caching.set(key, value, ttl=ttl, nx=nx)
+
+
+def _cache_delete(key: str) -> None:
+    ProviderManager().caching.delete(key)
+
+
+def _load_cached_json(key: str) -> dict[str, Any] | None:
+    raw = _cache_get(key)
+    if raw is None:
+        return None
+    if isinstance(raw, (bytes, bytearray, memoryview)):
+        raw = bytes(raw)
+    try:
+        return orjson.loads(raw)
+    except orjson.JSONDecodeError:
+        _cache_delete(key)
+        return None
+
+
+def _store_json(key: str, value: dict[str, Any], ttl: float, nx: bool = False) -> bool:
+    return _cache_set(key, orjson.dumps(value).decode("utf-8"), ttl=ttl, nx=nx)
+
+
+def _fetch_discovery_document(issuer: str) -> dict[str, Any]:
+    response = requests.get(
+        f"{issuer}/.well-known/openid-configuration",
+        timeout=DEFAULT_HTTP_TIMEOUT_SECONDS,
+    )
+    response.raise_for_status()
+    metadata = response.json()
+    if not isinstance(metadata, dict):
+        raise OIDCConfigurationError("OIDC discovery document is invalid")
+    return metadata
+
+
+def _get_provider_metadata(cfg: dict[str, Any]) -> dict[str, Any]:
+    cache_key = (
+        METADATA_CACHE_PREFIX
+        + hashlib.sha256(cfg["issuer"].encode("utf-8")).hexdigest()
+    )
+    cached = _load_cached_json(cache_key)
+    if cached is not None:
+        return cached
+
+    metadata = _fetch_discovery_document(cfg["issuer"])
+    metadata_issuer = str(metadata.get("issuer", "")).rstrip("/")
+    if metadata_issuer != cfg["issuer"]:
+        raise OIDCConfigurationError("OIDC discovery issuer does not match config")
+
+    required = ("authorization_endpoint", "token_endpoint", "jwks_uri")
+    missing = [field for field in required if not metadata.get(field)]
+    if missing:
+        raise OIDCConfigurationError(
+            "OIDC discovery document is missing: " + ", ".join(missing)
+        )
+
+    _store_json(cache_key, metadata, ttl=3600)
+    return metadata
+
+
+def _base64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _new_pkce_verifier() -> str:
+    return _base64url(secrets.token_bytes(32))
+
+
+def _pkce_challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return _base64url(digest)
+
+
+def _state_cache_key(state: str) -> str:
+    return STATE_CACHE_PREFIX + state
+
+
+def _save_state(cfg: dict[str, Any], state_data: dict[str, Any]) -> bool:
+    return _store_json(
+        _state_cache_key(state_data["state"]),
+        state_data,
+        ttl=cfg["state_ttl_seconds"],
+        nx=True,
+    )
+
+
+def _pop_state(state: str) -> dict[str, Any] | None:
+    cache_key = _state_cache_key(state)
+    state_data = _load_cached_json(cache_key)
+    _cache_delete(cache_key)
+    return state_data
+
+
+def _make_oauth_client(cfg: dict[str, Any], redirect_uri: str) -> OAuth2Session:
+    token_auth_method = "client_secret_basic" if cfg["client_secret"] else "none"
+    return OAuth2Session(
+        client_id=cfg["client_id"],
+        client_secret=cfg["client_secret"] or None,
+        scope=cfg["scope"],
+        redirect_uri=redirect_uri,
+        token_endpoint_auth_method=token_auth_method,
+    )
+
+
+def _create_authorization_url(
+    cfg: dict[str, Any],
+    metadata: dict[str, Any],
+    redirect_uri: str,
+) -> tuple[str, dict[str, Any]]:
+    for _attempt in range(3):
+        state = secrets.token_urlsafe(32)
+        nonce = secrets.token_urlsafe(32)
+        code_verifier = _new_pkce_verifier()
+
+        client = _make_oauth_client(cfg, redirect_uri)
+        authorization_url, returned_state = client.create_authorization_url(
+            metadata["authorization_endpoint"],
+            state=state,
+            nonce=nonce,
+            code_challenge=_pkce_challenge(code_verifier),
+            code_challenge_method="S256",
+        )
+        state_data = {
+            "state": returned_state,
+            "nonce": nonce,
+            "code_verifier": code_verifier,
+            "redirect_uri": redirect_uri,
+            "created_at": time.time(),
+        }
+        if _save_state(cfg, state_data):
+            return authorization_url, state_data
+
+    raise OIDCConfigurationError("Could not allocate a unique OIDC state")
+
+
+def _exchange_code_for_token(
+    cfg: dict[str, Any],
+    metadata: dict[str, Any],
+    code: str,
+    state_data: dict[str, Any],
+) -> dict[str, Any]:
+    client = _make_oauth_client(cfg, state_data["redirect_uri"])
+    token = client.fetch_token(
+        metadata["token_endpoint"],
+        code=code,
+        grant_type="authorization_code",
+        redirect_uri=state_data["redirect_uri"],
+        code_verifier=state_data["code_verifier"],
+    )
+    return dict(token)
+
+
+def _validate_id_token(
+    cfg: dict[str, Any],
+    metadata: dict[str, Any],
+    token: dict[str, Any],
+    expected_nonce: str,
+) -> dict[str, Any]:
+    id_token = token.get("id_token")
+    if not id_token:
+        raise OIDCAuthenticationError("OIDC provider did not return an ID token")
+
+    jwks_client = jwt.PyJWKClient(metadata["jwks_uri"])
+    signing_key = jwks_client.get_signing_key_from_jwt(id_token)
+    supported_algs = metadata.get("id_token_signing_alg_values_supported") or ["RS256"]
+    algorithms = [alg for alg in supported_algs if alg != "none"]
+    claims = jwt.decode(
+        id_token,
+        signing_key.key,
+        algorithms=algorithms,
+        audience=cfg["client_id"],
+        issuer=metadata["issuer"],
+        options={"require": ["exp", "iat", "iss", "sub", "aud"]},
+    )
+
+    if claims.get("nonce") != expected_nonce:
+        raise OIDCAuthenticationError("OIDC nonce validation failed")
+
+    audience = claims.get("aud")
+    if isinstance(audience, list) and len(audience) > 1:
+        if claims.get("azp") != cfg["client_id"]:
+            raise OIDCAuthenticationError("OIDC authorized party validation failed")
+
+    return claims
+
+
+def _resolve_or_create_user(cfg: dict[str, Any], claims: dict[str, Any]) -> User | None:
+    username = claims.get(cfg["username_claim"])
+    if not isinstance(username, str) or not username:
+        raise OIDCAuthenticationError(
+            f"OIDC claim '{cfg['username_claim']}' is missing"
+        )
+
+    with Session() as session:
+        user = session.get(User, username)
+        if user is not None:
+            return user
+
+    if not cfg["auto_provision"]:
+        return None
+
+    default_groups = cfg["default_groups"]
+    with Session() as session:
+        existing_groups = {
+            group_name
+            for (group_name,) in session.query(UserGroup.group_name)
+            .filter(UserGroup.group_name.in_(default_groups))
+            .all()
+        }
+    missing_groups = set(default_groups) - existing_groups
+    if missing_groups:
+        raise OIDCConfigurationError(
+            "OIDC auto_provision references missing groups: "
+            + ", ".join(sorted(missing_groups))
+        )
+
+    now = time.time()
+    create_user(
+        username=username,
+        password=secrets.token_urlsafe(48),
+        nickname=claims.get("name") or username,
+        groups=[
+            {"group_name": group_name, "start_time": now, "end_time": None}
+            for group_name in default_groups
+        ],
+        permissions=[],
+    )
+
+    with Session() as session:
+        return session.get(User, username)
+
+
+class RequestOIDCStartHandler(RequestHandler):
+    schema = {
+        "type": "object",
+        "properties": {
+            "redirect_uri": {"type": "string", "minLength": 1},
+        },
+        "additionalProperties": False,
+    }
+
+    def handle(self, handler: ConnectionHandler) -> Result | None:
+        try:
+            cfg = _require_enabled_config()
+            redirect_uri = handler.data.get("redirect_uri") or cfg["redirect_uri"]
+            metadata = _get_provider_metadata(cfg)
+            authorization_url, state_data = _create_authorization_url(
+                cfg, metadata, redirect_uri
+            )
+        except OIDCConfigurationError as exc:
+            handler.conclude_request(400, {}, str(exc))
+            return Result(code=400)
+        except Exception as exc:
+            logger.exception("Failed to start OIDC SSO")
+            handler.report_error(exc, context="Failed to start OIDC SSO")
+            return None
+
+        handler.conclude_request(
+            200,
+            {
+                "authorization_url": authorization_url,
+                "state": state_data["state"],
+                "expires_in": cfg["state_ttl_seconds"],
+            },
+            "OIDC authorization URL created",
+        )
+        return Result(code=200)
+
+
+class RequestOIDCCallbackHandler(RequestHandler):
+    schema = {
+        "type": "object",
+        "properties": {
+            "state": {"type": "string", "minLength": 1},
+            "code": {"type": "string", "minLength": 1},
+            "redirect_uri": {"type": "string", "minLength": 1},
+            "error": {"type": "string", "minLength": 1},
+            "error_description": {"type": "string"},
+        },
+        "required": ["state"],
+        "additionalProperties": False,
+    }
+
+    def handle(self, handler: ConnectionHandler) -> Result | None:
+        state = handler.data["state"]
+        error = handler.data.get("error")
+        if error:
+            message = handler.data.get("error_description") or error
+            handler.conclude_request(401, {"error": error}, message)
+            return Result(code=401)
+
+        code = handler.data.get("code")
+        if not code:
+            handler.conclude_request(400, {}, "OIDC authorization code is required")
+            return Result(code=400)
+
+        try:
+            cfg = _require_enabled_config()
+            state_data = _pop_state(state)
+            if state_data is None:
+                handler.conclude_request(401, {}, "Invalid or expired OIDC state")
+                return Result(code=401)
+
+            if handler.data.get("redirect_uri"):
+                state_redirect_uri = state_data["redirect_uri"]
+                if handler.data["redirect_uri"] != state_redirect_uri:
+                    handler.conclude_request(401, {}, "OIDC redirect_uri mismatch")
+                    return Result(code=401)
+
+            metadata = _get_provider_metadata(cfg)
+            oidc_token = _exchange_code_for_token(cfg, metadata, code, state_data)
+            claims = _validate_id_token(cfg, metadata, oidc_token, state_data["nonce"])
+            user = _resolve_or_create_user(cfg, claims)
+            if user is None:
+                handler.conclude_request(401, {}, "SSO user is not allowed")
+                return Result(code=401)
+
+            with Session() as session:
+                user = User.get_existing(session, user.username)
+                token = issue_login_token(user)
+                data = build_login_success_data(session, user, token)
+        except UserNotActiveError:
+            handler.conclude_request(4003, {}, "User account is not active")
+            return Result(code=4003)
+        except (OIDCConfigurationError, OIDCAuthenticationError, jwt.PyJWTError) as exc:
+            handler.conclude_request(401, {}, str(exc))
+            return Result(code=401)
+        except Exception as exc:
+            logger.exception("Failed to complete OIDC SSO")
+            handler.report_error(exc, context="Failed to complete OIDC SSO")
+            return None
+
+        handler.conclude_request(200, data, "Login successful")
+        return Result(code=200, target=user.username, username=user.username)
+
+
+@hookimpl
+def ext_register_handlers() -> dict[str, type[RequestHandler]]:
+    return {
+        "sso_oidc_start": RequestOIDCStartHandler,
+        "sso_oidc_callback": RequestOIDCCallbackHandler,
+    }
+
+
+@hookimpl
+def ext_register_whitelisted_actions() -> set[str]:
+    return {"sso_oidc_start", "sso_oidc_callback"}

--- a/src/include/extensions/oidc_sso/_extension.py
+++ b/src/include/extensions/oidc_sso/_extension.py
@@ -423,10 +423,14 @@ class RequestOIDCCallbackHandler(RequestHandler):
                 handler.conclude_request(401, {}, "SSO user is not allowed")
                 return Result(code=401)
 
+            username = user.username
             with Session() as session:
-                user = User.get_existing(session, user.username)
+                user = User.get_existing(session, username)
                 token = issue_login_token(user)
                 data = build_login_success_data(session, user, token)
+
+                user.last_login = time.time()
+                session.commit()
         except UserNotActiveError:
             handler.conclude_request(4003, {}, "User account is not active")
             return Result(code=4003)
@@ -439,7 +443,7 @@ class RequestOIDCCallbackHandler(RequestHandler):
             return None
 
         handler.conclude_request(200, data, "Login successful")
-        return Result(code=200, target=user.username, username=user.username)
+        return Result(code=200, target=username, username=username)
 
 
 @hookimpl

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -15,9 +15,15 @@ class TestServerBasics:
         response = await client.server_info()
         data = assert_success(response)
 
-        required_fields = ["server_name", "version", "protocol_version"]
+        required_fields = [
+            "server_name",
+            "version",
+            "protocol_version",
+            "extension_flags",
+        ]
         for field in required_fields:
             assert field in data
+        assert isinstance(data["extension_flags"], list)
 
     @pytest.mark.asyncio
     async def test_unknown_action(self, client: CFMSTestClient):

--- a/tests/test_directory_deletion.py
+++ b/tests/test_directory_deletion.py
@@ -59,3 +59,63 @@ def test_mark_nodes_deleted_updates_node_table_for_joined_inheritance(
         assert document_node.status_operation_id == "operation-1"
 
     global_config.stop()
+
+
+def test_deleting_revision_sets_document_and_child_revision_references_null(
+    monkeypatch, tmp_path
+):
+    _prepare_config(monkeypatch, tmp_path)
+
+    from include.database import models
+    from include.database.session import Base, global_config
+
+    engine = create_engine("sqlite:///:memory:")
+
+    @event.listens_for(engine, "connect")
+    def _enable_sqlite_foreign_keys(dbapi_connection, _connection_record):
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
+
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+
+    with SessionLocal() as session:
+        document = models.Document(id="document-1", title="document")
+        first_file = models.File(id="file-1", path="/missing/file-1", active=True)
+        second_file = models.File(id="file-2", path="/missing/file-2", active=True)
+        session.add_all([document, first_file, second_file])
+        session.flush()
+
+        first_revision = models.DocumentRevision(
+            id="revision-1",
+            document=document,
+            file=first_file,
+        )
+        second_revision = models.DocumentRevision(
+            id="revision-2",
+            document=document,
+            file=second_file,
+            parent_revision=first_revision,
+        )
+        session.add_all([first_revision, second_revision])
+        session.flush()
+
+        document.current_revision = first_revision
+        session.commit()
+
+        session.execute(
+            models.DocumentRevision.__table__.delete().where(
+                models.DocumentRevision.id == first_revision.id
+            )
+        )
+        session.commit()
+
+        session.expire_all()
+        assert session.get(models.Document, document.id).current_revision_id is None
+        assert (
+            session.get(models.DocumentRevision, second_revision.id).parent_revision_id
+            is None
+        )
+
+    global_config.stop()

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -139,6 +139,13 @@ def test_collect_extension_flags_returns_sorted_unique_strings(monkeypatch):
     assert extension_manager.collect_extension_flags() == ["alpha", "beta", "zeta"]
 
 
+def test_collect_extension_flags_with_no_plugins(monkeypatch):
+    pm = _fresh_plugin_manager()
+    monkeypatch.setattr(extension_manager, "pm", pm)
+
+    assert extension_manager.collect_extension_flags() == []
+
+
 def test_collect_extension_flags_ignores_non_string_flags(monkeypatch):
     pm = _fresh_plugin_manager()
     monkeypatch.setattr(extension_manager, "pm", pm)
@@ -151,3 +158,23 @@ def test_collect_extension_flags_ignores_non_string_flags(monkeypatch):
     pm.register(Extension())
 
     assert extension_manager.collect_extension_flags() == ["alpha"]
+
+
+def test_collect_extension_flags_skips_none_results(monkeypatch):
+    pm = _fresh_plugin_manager()
+    monkeypatch.setattr(extension_manager, "pm", pm)
+
+    class SetReturningExtension:
+        @extension_manager.hookimpl
+        def ext_register_extension_flags(self):
+            return {"delta", "alpha"}
+
+    class NoneReturningExtension:
+        @extension_manager.hookimpl
+        def ext_register_extension_flags(self):
+            return None
+
+    pm.register(SetReturningExtension())
+    pm.register(NoneReturningExtension())
+
+    assert extension_manager.collect_extension_flags() == ["alpha", "delta"]

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -117,3 +117,37 @@ def test_builtin_extension_loads_quietly_and_is_not_loaded_twice(monkeypatch, tm
     assert pm.has_plugin("builtin")
     assert counter_path.read_text(encoding="utf-8") == "1"
     assert info_messages == []
+
+
+def test_collect_extension_flags_returns_sorted_unique_strings(monkeypatch):
+    pm = _fresh_plugin_manager()
+    monkeypatch.setattr(extension_manager, "pm", pm)
+
+    class FirstExtension:
+        @extension_manager.hookimpl
+        def ext_register_extension_flags(self):
+            return {"zeta", "alpha"}
+
+    class SecondExtension:
+        @extension_manager.hookimpl
+        def ext_register_extension_flags(self):
+            return {"alpha", "beta"}
+
+    pm.register(FirstExtension())
+    pm.register(SecondExtension())
+
+    assert extension_manager.collect_extension_flags() == ["alpha", "beta", "zeta"]
+
+
+def test_collect_extension_flags_ignores_non_string_flags(monkeypatch):
+    pm = _fresh_plugin_manager()
+    monkeypatch.setattr(extension_manager, "pm", pm)
+
+    class Extension:
+        @extension_manager.hookimpl
+        def ext_register_extension_flags(self):
+            return {"alpha", 123}
+
+    pm.register(Extension())
+
+    assert extension_manager.collect_extension_flags() == ["alpha"]

--- a/tests/test_identity_sessions.py
+++ b/tests/test_identity_sessions.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+from shutil import copyfile
+from types import SimpleNamespace
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _prepare_config(monkeypatch, tmp_path):
+    copyfile(PROJECT_ROOT / "src" / "config.toml.sample", tmp_path / "config.toml")
+    monkeypatch.chdir(tmp_path)
+
+
+def test_issue_login_token_only_renews_token(monkeypatch, tmp_path):
+    _prepare_config(monkeypatch, tmp_path)
+    from include.database.models.identity import UserStatus
+    from include.domains.identity.sessions import issue_login_token
+
+    token = object()
+    user = SimpleNamespace(
+        status=UserStatus.ACTIVE,
+        last_login=None,
+        renew_token=lambda: token,
+    )
+
+    assert issue_login_token(user) is token
+    assert user.last_login is None

--- a/tests/test_oidc_sso.py
+++ b/tests/test_oidc_sso.py
@@ -168,8 +168,10 @@ def test_oidc_start_creates_authorization_url_and_state(monkeypatch, oidc):
 
 
 def test_oidc_callback_success_uses_existing_login_response(monkeypatch, oidc):
-    user = SimpleNamespace(username="alice")
+    user = SimpleNamespace(username="alice", last_login=None)
+    session_events = []
     monkeypatch.setattr(oidc, "global_config", DummyConfig(_enabled_config()))
+    monkeypatch.setattr(oidc.time, "time", lambda: 123.0)
     monkeypatch.setattr(oidc, "_pop_state", lambda state: {"nonce": "nonce"})
     monkeypatch.setattr(oidc, "_get_provider_metadata", lambda cfg: _metadata())
     monkeypatch.setattr(
@@ -182,11 +184,12 @@ def test_oidc_callback_success_uses_existing_login_response(monkeypatch, oidc):
     )
     monkeypatch.setattr(oidc, "_resolve_or_create_user", lambda cfg, claims: user)
     monkeypatch.setattr(oidc, "issue_login_token", lambda resolved_user: "token")
-    monkeypatch.setattr(
-        oidc,
-        "build_login_success_data",
-        lambda session, resolved_user, token: {"token": "cfms-token"},
-    )
+
+    def build_login_success_data(session, resolved_user, token):
+        session_events.append(("build", resolved_user.last_login))
+        return {"token": "cfms-token"}
+
+    monkeypatch.setattr(oidc, "build_login_success_data", build_login_success_data)
 
     class DummySession:
         def __enter__(self):
@@ -199,6 +202,10 @@ def test_oidc_callback_success_uses_existing_login_response(monkeypatch, oidc):
             assert ident == "alice"
             return user
 
+        def commit(self):
+            session_events.append(("commit", user.last_login))
+            del user.username
+
     monkeypatch.setattr(oidc, "Session", DummySession)
 
     handler = DummyHandler({"state": "state", "code": "code"})
@@ -206,6 +213,8 @@ def test_oidc_callback_success_uses_existing_login_response(monkeypatch, oidc):
 
     assert result.code == 200
     assert result.target == "alice"
+    assert user.last_login == 123.0
+    assert session_events == [("build", None), ("commit", 123.0)]
     assert handler.responses[-1] == {
         "code": 200,
         "data": {"token": "cfms-token"},

--- a/tests/test_oidc_sso.py
+++ b/tests/test_oidc_sso.py
@@ -1,0 +1,386 @@
+import importlib
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import jwt
+import orjson
+import pytest
+
+from include.exceptions.misc import UserNotActiveError
+
+
+@pytest.fixture(scope="module")
+def oidc():
+    old_cwd = os.getcwd()
+    src_dir = Path(__file__).resolve().parents[1] / "src"
+    os.chdir(src_dir)
+    try:
+        module = importlib.import_module("include.extensions.oidc_sso._extension")
+    finally:
+        os.chdir(old_cwd)
+    yield module
+    try:
+        from sqlalchemy.orm import close_all_sessions
+
+        from include.database.session import engine
+
+        close_all_sessions()
+        engine.dispose()
+    except Exception:
+        pass
+
+
+class DummyConfig:
+    def __init__(self, oidc_config):
+        self._oidc_config = oidc_config
+
+    def get(self, key, default=None):
+        if key == "sso":
+            return {"oidc": self._oidc_config}
+        return default
+
+
+class DummyHandler:
+    def __init__(self, data):
+        self.data = data
+        self.responses = []
+
+    def conclude_request(self, code, data=None, message=""):
+        self.responses.append(
+            {
+                "code": code,
+                "data": data if data is not None else {},
+                "message": message,
+            }
+        )
+
+    def report_error(self, exc, code=500, context=None, send_to_client=True):
+        if send_to_client:
+            self.conclude_request(code, {"error": type(exc).__name__}, context or "")
+        return "log-id"
+
+
+def _enabled_config(**overrides):
+    config = {
+        "enabled": True,
+        "issuer": "https://issuer.example",
+        "client_id": "cfms-client",
+        "client_secret": "secret",
+        "redirect_uri": "https://client.example/callback",
+        "username_claim": "preferred_username",
+        "auto_provision": False,
+        "default_groups": ["user"],
+    }
+    config.update(overrides)
+    return config
+
+
+def _metadata():
+    return {
+        "issuer": "https://issuer.example",
+        "authorization_endpoint": "https://issuer.example/authorize",
+        "token_endpoint": "https://issuer.example/token",
+        "jwks_uri": "https://issuer.example/jwks",
+    }
+
+
+def _install_memory_cache(monkeypatch, oidc):
+    cache = {}
+
+    def cache_get(key):
+        item = cache.get(key)
+        if item is None:
+            return None
+        return item["value"]
+
+    def cache_set(key, value, ttl=None, nx=False):
+        if nx and key in cache:
+            return False
+        cache[key] = {"value": value, "ttl": ttl}
+        return True
+
+    def cache_delete(key):
+        cache.pop(key, None)
+
+    monkeypatch.setattr(oidc, "_cache_get", cache_get)
+    monkeypatch.setattr(oidc, "_cache_set", cache_set)
+    monkeypatch.setattr(oidc, "_cache_delete", cache_delete)
+    return cache
+
+
+def test_oidc_extension_registers_handlers_and_whitelist(oidc):
+    handlers = oidc.ext_register_handlers()
+
+    assert handlers["sso_oidc_start"] is oidc.RequestOIDCStartHandler
+    assert handlers["sso_oidc_callback"] is oidc.RequestOIDCCallbackHandler
+    assert oidc.ext_register_whitelisted_actions() == {
+        "sso_oidc_start",
+        "sso_oidc_callback",
+    }
+
+
+def test_oidc_start_creates_authorization_url_and_state(monkeypatch, oidc):
+    monkeypatch.setattr(oidc, "global_config", DummyConfig(_enabled_config()))
+    monkeypatch.setattr(oidc, "_fetch_discovery_document", lambda issuer: _metadata())
+    cache = _install_memory_cache(monkeypatch, oidc)
+
+    handler = DummyHandler({})
+    result = oidc.RequestOIDCStartHandler().handle(handler)
+
+    assert result.code == 200
+    response = handler.responses[-1]
+    data = response["data"]
+    assert response["code"] == 200
+    assert data["expires_in"] == 300
+
+    parsed = urlparse(data["authorization_url"])
+    query = parse_qs(parsed.query)
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == (
+        "https://issuer.example/authorize"
+    )
+    assert query["client_id"] == ["cfms-client"]
+    assert query["redirect_uri"] == ["https://client.example/callback"]
+    assert query["response_type"] == ["code"]
+    assert query["scope"] == ["openid profile email"]
+    assert query["state"] == [data["state"]]
+    assert query["code_challenge_method"] == ["S256"]
+    assert query["nonce"]
+
+    state_entry = cache[oidc.STATE_CACHE_PREFIX + data["state"]]
+    state_data = orjson.loads(state_entry["value"])
+    assert state_entry["ttl"] == 300
+    assert state_data["state"] == data["state"]
+    assert state_data["nonce"] == query["nonce"][0]
+    assert state_data["redirect_uri"] == "https://client.example/callback"
+    assert state_data["code_verifier"]
+
+
+def test_oidc_callback_success_uses_existing_login_response(monkeypatch, oidc):
+    user = SimpleNamespace(username="alice")
+    monkeypatch.setattr(oidc, "global_config", DummyConfig(_enabled_config()))
+    monkeypatch.setattr(oidc, "_pop_state", lambda state: {"nonce": "nonce"})
+    monkeypatch.setattr(oidc, "_get_provider_metadata", lambda cfg: _metadata())
+    monkeypatch.setattr(
+        oidc, "_exchange_code_for_token", lambda cfg, metadata, code, state: {}
+    )
+    monkeypatch.setattr(
+        oidc,
+        "_validate_id_token",
+        lambda cfg, metadata, token, expected_nonce: {"preferred_username": "alice"},
+    )
+    monkeypatch.setattr(oidc, "_resolve_or_create_user", lambda cfg, claims: user)
+    monkeypatch.setattr(oidc, "issue_login_token", lambda resolved_user: "token")
+    monkeypatch.setattr(
+        oidc,
+        "build_login_success_data",
+        lambda session, resolved_user, token: {"token": "cfms-token"},
+    )
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return None
+
+        def get(self, model, ident):
+            assert ident == "alice"
+            return user
+
+    monkeypatch.setattr(oidc, "Session", DummySession)
+
+    handler = DummyHandler({"state": "state", "code": "code"})
+    result = oidc.RequestOIDCCallbackHandler().handle(handler)
+
+    assert result.code == 200
+    assert result.target == "alice"
+    assert handler.responses[-1] == {
+        "code": 200,
+        "data": {"token": "cfms-token"},
+        "message": "Login successful",
+    }
+
+
+def test_oidc_callback_rejects_expired_state(monkeypatch, oidc):
+    monkeypatch.setattr(oidc, "global_config", DummyConfig(_enabled_config()))
+    monkeypatch.setattr(oidc, "_pop_state", lambda state: None)
+
+    handler = DummyHandler({"state": "expired", "code": "code"})
+    result = oidc.RequestOIDCCallbackHandler().handle(handler)
+
+    assert result.code == 401
+    assert handler.responses[-1]["message"] == "Invalid or expired OIDC state"
+
+
+def test_oidc_callback_rejects_unknown_user(monkeypatch, oidc):
+    monkeypatch.setattr(oidc, "global_config", DummyConfig(_enabled_config()))
+    monkeypatch.setattr(oidc, "_pop_state", lambda state: {"nonce": "nonce"})
+    monkeypatch.setattr(oidc, "_get_provider_metadata", lambda cfg: _metadata())
+    monkeypatch.setattr(
+        oidc, "_exchange_code_for_token", lambda cfg, metadata, code, state: {}
+    )
+    monkeypatch.setattr(
+        oidc,
+        "_validate_id_token",
+        lambda cfg, metadata, token, expected_nonce: {"preferred_username": "alice"},
+    )
+    monkeypatch.setattr(oidc, "_resolve_or_create_user", lambda cfg, claims: None)
+
+    handler = DummyHandler({"state": "state", "code": "code"})
+    result = oidc.RequestOIDCCallbackHandler().handle(handler)
+
+    assert result.code == 401
+    assert handler.responses[-1]["message"] == "SSO user is not allowed"
+
+
+def test_oidc_callback_rejects_disabled_user(monkeypatch, oidc):
+    user = SimpleNamespace(username="alice")
+    monkeypatch.setattr(oidc, "global_config", DummyConfig(_enabled_config()))
+    monkeypatch.setattr(oidc, "_pop_state", lambda state: {"nonce": "nonce"})
+    monkeypatch.setattr(oidc, "_get_provider_metadata", lambda cfg: _metadata())
+    monkeypatch.setattr(
+        oidc, "_exchange_code_for_token", lambda cfg, metadata, code, state: {}
+    )
+    monkeypatch.setattr(
+        oidc,
+        "_validate_id_token",
+        lambda cfg, metadata, token, expected_nonce: {"preferred_username": "alice"},
+    )
+    monkeypatch.setattr(oidc, "_resolve_or_create_user", lambda cfg, claims: user)
+    monkeypatch.setattr(
+        oidc,
+        "issue_login_token",
+        lambda resolved_user: (_ for _ in ()).throw(UserNotActiveError()),
+    )
+
+    class DummySession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc_value, traceback):
+            return None
+
+        def get(self, model, ident):
+            return user
+
+    monkeypatch.setattr(oidc, "Session", DummySession)
+
+    handler = DummyHandler({"state": "state", "code": "code"})
+    result = oidc.RequestOIDCCallbackHandler().handle(handler)
+
+    assert result.code == 4003
+    assert handler.responses[-1]["message"] == "User account is not active"
+
+
+def test_validate_id_token_checks_signature_audience_issuer_and_nonce(
+    monkeypatch, oidc
+):
+    class DummyKey:
+        key = "public-key"
+
+    class DummyJWKClient:
+        def __init__(self, jwks_uri):
+            assert jwks_uri == "https://issuer.example/jwks"
+
+        def get_signing_key_from_jwt(self, token):
+            assert token == "id-token"
+            return DummyKey()
+
+    def decode(token, key, algorithms, audience, issuer, options):
+        assert token == "id-token"
+        assert key == "public-key"
+        assert algorithms == ["RS256"]
+        assert audience == "cfms-client"
+        assert issuer == "https://issuer.example"
+        assert options["require"] == ["exp", "iat", "iss", "sub", "aud"]
+        return {
+            "iss": issuer,
+            "aud": audience,
+            "sub": "subject",
+            "iat": 1,
+            "exp": 2,
+            "nonce": "expected",
+            "preferred_username": "alice",
+        }
+
+    monkeypatch.setattr(oidc.jwt, "PyJWKClient", DummyJWKClient)
+    monkeypatch.setattr(oidc.jwt, "decode", decode)
+
+    claims = oidc._validate_id_token(
+        {"client_id": "cfms-client"},
+        _metadata(),
+        {"id_token": "id-token"},
+        "expected",
+    )
+
+    assert claims["preferred_username"] == "alice"
+
+
+def test_validate_id_token_rejects_nonce_mismatch(monkeypatch, oidc):
+    class DummyKey:
+        key = "public-key"
+
+    class DummyJWKClient:
+        def __init__(self, jwks_uri):
+            pass
+
+        def get_signing_key_from_jwt(self, token):
+            return DummyKey()
+
+    monkeypatch.setattr(oidc.jwt, "PyJWKClient", DummyJWKClient)
+    monkeypatch.setattr(
+        oidc.jwt,
+        "decode",
+        lambda *args, **kwargs: {
+            "iss": "https://issuer.example",
+            "aud": "cfms-client",
+            "sub": "subject",
+            "iat": 1,
+            "exp": 2,
+            "nonce": "wrong",
+        },
+    )
+
+    try:
+        oidc._validate_id_token(
+            {"client_id": "cfms-client"},
+            _metadata(),
+            {"id_token": "id-token"},
+            "expected",
+        )
+    except oidc.OIDCAuthenticationError as exc:
+        assert str(exc) == "OIDC nonce validation failed"
+    else:
+        raise AssertionError("Expected nonce mismatch to be rejected")
+
+
+def test_validate_id_token_surfaces_audience_or_issuer_errors(monkeypatch, oidc):
+    class DummyKey:
+        key = "public-key"
+
+    class DummyJWKClient:
+        def __init__(self, jwks_uri):
+            pass
+
+        def get_signing_key_from_jwt(self, token):
+            return DummyKey()
+
+    def decode(*args, **kwargs):
+        raise jwt.InvalidAudienceError("Audience doesn't match")
+
+    monkeypatch.setattr(oidc.jwt, "PyJWKClient", DummyJWKClient)
+    monkeypatch.setattr(oidc.jwt, "decode", decode)
+
+    try:
+        oidc._validate_id_token(
+            {"client_id": "cfms-client"},
+            _metadata(),
+            {"id_token": "id-token"},
+            "expected",
+        )
+    except jwt.InvalidAudienceError:
+        pass
+    else:
+        raise AssertionError("Expected PyJWT audience errors to surface")

--- a/tests/test_oidc_sso.py
+++ b/tests/test_oidc_sso.py
@@ -110,7 +110,9 @@ def _install_memory_cache(monkeypatch, oidc):
     return cache
 
 
-def test_oidc_extension_registers_handlers_and_whitelist(oidc):
+def test_oidc_extension_registers_handlers_whitelist_and_enabled_flag(
+    monkeypatch, oidc
+):
     handlers = oidc.ext_register_handlers()
 
     assert handlers["sso_oidc_start"] is oidc.RequestOIDCStartHandler
@@ -119,6 +121,14 @@ def test_oidc_extension_registers_handlers_and_whitelist(oidc):
         "sso_oidc_start",
         "sso_oidc_callback",
     }
+
+    monkeypatch.setattr(oidc, "global_config", DummyConfig(_enabled_config()))
+    assert oidc.ext_register_extension_flags() == {"oidc_sso"}
+
+    monkeypatch.setattr(
+        oidc, "global_config", DummyConfig(_enabled_config(enabled=False))
+    )
+    assert oidc.ext_register_extension_flags() == set()
 
 
 def test_oidc_start_creates_authorization_url_and_state(monkeypatch, oidc):


### PR DESCRIPTION
## Summary by Sourcery

Introduce an OpenID Connect SSO extension, expose extension capability flags via server info, and adjust document revision foreign key behavior to null out references instead of breaking relationships.

New Features:
- Add an OpenID Connect SSO extension that supports starting and completing OIDC-based single sign-on flows, including optional auto-provisioning of users.
- Expose extension capability flags from extensions and include them in the server_info response for clients.
- Add a reusable identity session helper module to issue login tokens and build consistent login success payloads.

Bug Fixes:
- Ensure deleting a document revision sets related document current_revision_id and child parent_revision_id references to NULL instead of leaving invalid references.

Enhancements:
- Extend the extension manager with a hook and utility for registering and aggregating extension capability flags, with validation and deduplication.
- Refactor login success response construction to a shared helper used by both password-based and OIDC-based authentication handlers.
- Update document and document revision models and migrations so foreign keys to revisions use ON DELETE SET NULL semantics and clean up orphaned references.

Build:
- Include optional dependencies for the OIDC SSO extension in the project extras configuration.

CI:
- Adjust the test workflow to fetch git submodules recursively and install all extras during dependency sync for more complete test coverage.

Tests:
- Add comprehensive tests for the new extension flag aggregation logic and its behavior with duplicate and invalid values.
- Add tests covering document revision deletion behavior to ensure document and child revision references are nulled correctly.
- Add extensive tests for the OIDC SSO extension covering handler registration, start and callback flows, ID token validation, and error cases.